### PR TITLE
Match device whitelist/blacklist by device ID, name or name_by_user

### DIFF
--- a/matterbridge-hass.schema.json
+++ b/matterbridge-hass.schema.json
@@ -32,14 +32,14 @@
       "default": 60
     },
     "blackList": {
-      "description": "The devices in the list will not be exposed. Use the device name.",
+      "description": "The devices in the list will not be exposed. Use the device ID or name.",
       "type": "array",
       "items": {
         "type": "string"
       }
     },
     "whiteList": {
-      "description": "Only the devices in the list will be exposed. Use the device name.",
+      "description": "Only the devices in the list will be exposed. Use the device ID or name.",
       "type": "array",
       "items": {
         "type": "string"

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -196,17 +196,17 @@ describe('HassPlatform', () => {
   it('should validate with white and black list', () => {
     haPlatform.config.whiteList = ['whiteDevice'];
     haPlatform.config.blackList = ['blackDevice'];
-    expect(haPlatform._validateDeviceWhiteBlackList('whiteDevice')).toBe(true);
-    expect(haPlatform._validateDeviceWhiteBlackList('blackDevice')).toBe(false);
-    expect(haPlatform._validateDeviceWhiteBlackList('xDevice')).toBe(false);
-    expect(haPlatform._validateDeviceWhiteBlackList('')).toBe(false);
+    expect(haPlatform._validateDeviceWhiteBlackList({ id: '12345', name: 'whiteDevice', name_by_user: null })).toBe(true);
+    expect(haPlatform._validateDeviceWhiteBlackList({ id: '12345', name: 'blackDevice', name_by_user: null })).toBe(false);
+    expect(haPlatform._validateDeviceWhiteBlackList({ id: '12345', name: 'xDevice', name_by_user: null })).toBe(false);
+    expect(haPlatform._validateDeviceWhiteBlackList({ id: '12345', name: '', name_by_user: null })).toBe(false);
 
     haPlatform.config.whiteList = [];
     haPlatform.config.blackList = ['blackDevice'];
-    expect(haPlatform._validateDeviceWhiteBlackList('whiteDevice')).toBe(true);
-    expect(haPlatform._validateDeviceWhiteBlackList('blackDevice')).toBe(false);
-    expect(haPlatform._validateDeviceWhiteBlackList('xDevice')).toBe(true);
-    expect(haPlatform._validateDeviceWhiteBlackList('')).toBe(true);
+    expect(haPlatform._validateDeviceWhiteBlackList({ id: '12345', name: 'whiteDevice', name_by_user: null })).toBe(true);
+    expect(haPlatform._validateDeviceWhiteBlackList({ id: '12345', name: 'blackDevice', name_by_user: null })).toBe(false);
+    expect(haPlatform._validateDeviceWhiteBlackList({ id: '12345', name: 'xDevice', name_by_user: null })).toBe(true);
+    expect(haPlatform._validateDeviceWhiteBlackList({ id: '12345', name: '', name_by_user: null })).toBe(true);
 
     haPlatform.config.whiteList = [];
     haPlatform.config.blackList = [];
@@ -760,6 +760,19 @@ describe('HassPlatform', () => {
     expect(mockMatterbridge.removeAllBridgedDevices).toHaveBeenCalled();
     await wait(1000);
   }, 20000);
+
+  it('should match device id or name', () => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const device = (mockData.devices as HassDevice[]).find((d) => d.id === 'd1ecb5ba126bd056b9388a96fed5da74')!;
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(haPlatform._matchStringListWithDevice([device.id!], device)).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(haPlatform._matchStringListWithDevice([device.name!], device)).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(haPlatform._matchStringListWithDevice([device.name_by_user!], device)).toBe(true);
+    expect(haPlatform._matchStringListWithDevice(['abcd'], device)).toBe(false);
+  });
 });
 
 const switchDevice = {


### PR DESCRIPTION
Instead of just device name which sometimes can be something arbitrary and weird like `_TZ3000_9wizooxd TS011F` for Zigbee devices.

This pattern could also be extended to entity blacklist and device entity black list but I wanted to get feedback first.