### PR TITLE
Add support for input_booleans

### DIFF
--- a/src/converters.ts
+++ b/src/converters.ts
@@ -79,6 +79,9 @@ export const hassUpdateStateConverter: { domain: string; state: string; clusterI
     { domain: 'climate', state: 'heat', clusterId: Thermostat.Cluster.id, attribute: 'systemMode', value: Thermostat.SystemMode.Heat },
     { domain: 'climate', state: 'cool', clusterId: Thermostat.Cluster.id, attribute: 'systemMode', value: Thermostat.SystemMode.Cool },
     { domain: 'climate', state: 'heat_cool', clusterId: Thermostat.Cluster.id, attribute: 'systemMode', value: Thermostat.SystemMode.Auto },
+
+    { domain: 'input_boolean', state: 'on', clusterId: OnOff.Cluster.id, attribute: 'onOff', value: true },
+    { domain: 'input_boolean', state: 'off', clusterId: OnOff.Cluster.id, attribute: 'onOff', value: false },
   ];
 
 // Update Home Assistant attributes to Matterbridge device attributes
@@ -129,13 +132,14 @@ export const hassUpdateAttributeConverter: { domain: string; with: string; clust
 // Convert Home Assistant domains to Matterbridge device types and clusterIds
 // prettier-ignore
 export const hassDomainConverter: { domain: string; deviceType: DeviceTypeDefinition | null; clusterId: ClusterId | null }[] = [
-    { domain: 'switch',   deviceType: onOffOutlet,      clusterId: OnOff.Cluster.id },
-    { domain: 'light',    deviceType: onOffLight,       clusterId: OnOff.Cluster.id },
-    { domain: 'lock',     deviceType: doorLockDevice,   clusterId: DoorLock.Cluster.id },
-    { domain: 'fan',      deviceType: fanDevice,        clusterId: FanControl.Cluster.id },
-    { domain: 'cover',    deviceType: coverDevice,      clusterId: WindowCovering.Cluster.id },
-    { domain: 'climate',  deviceType: thermostatDevice, clusterId: Thermostat.Cluster.id },
-    { domain: 'sensor',   deviceType: null,             clusterId: null },
+    { domain: 'switch',         deviceType: onOffOutlet,      clusterId: OnOff.Cluster.id },
+    { domain: 'light',          deviceType: onOffLight,       clusterId: OnOff.Cluster.id },
+    { domain: 'lock',           deviceType: doorLockDevice,   clusterId: DoorLock.Cluster.id },
+    { domain: 'fan',            deviceType: fanDevice,        clusterId: FanControl.Cluster.id },
+    { domain: 'cover',          deviceType: coverDevice,      clusterId: WindowCovering.Cluster.id },
+    { domain: 'climate',        deviceType: thermostatDevice, clusterId: Thermostat.Cluster.id },
+    { domain: 'sensor',         deviceType: null,             clusterId: null },
+    { domain: 'input_boolean',  deviceType: onOffOutlet,      clusterId: OnOff.Cluster.id },
   ];
 
 // Convert Home Assistant domains attributes to Matterbridge device types and clusterIds
@@ -181,6 +185,10 @@ export const hassCommandConverter: { command: string; domain: string; service: s
     { command: 'downOrClose',             domain: 'cover', service: 'close_cover' },
     { command: 'stopMotion',              domain: 'cover', service: 'stop_cover' },
     { command: 'goToLiftPercentage',      domain: 'cover', service: 'set_cover_position', converter: (request: any) => { return { position: Math.round(100 - request.liftPercent100thsValue / 100) } } },
+
+    { command: 'on',                      domain: 'input_boolean', service: 'turn_on' },
+    { command: 'off',                     domain: 'input_boolean', service: 'turn_off' },
+    { command: 'toggle',                  domain: 'input_boolean', service: 'toggle' },
   ];
 
 // Convert Home Assistant domains services and attributes to Matterbridge subscribed cluster / attributes.

--- a/src/homeAssistant.ts
+++ b/src/homeAssistant.ts
@@ -381,13 +381,21 @@ export class HomeAssistant extends EventEmitter {
               this.log.debug(`Entity id ${CYAN}${response.event.data.entity_id}${db} not found processing event`);
               return;
             }
-            const device = this.hassDevices.get(entity.device_id);
-            if (!device) {
-              this.log.debug(`Device id ${CYAN}${entity.device_id}${db} not found processing event:`);
-              return;
+            // For bridgedHassEntities with no device_id, use the entity_id instead
+            let device_id;
+            if (!entity.device_id) {
+              this.log.debug(`Using ${CYAN}${entity.entity_id}${db} as the device_id`);
+              device_id = entity.entity_id;
+            } else {
+              const device = this.hassDevices.get(entity.device_id);
+              if (!device) {
+                this.log.debug(`Device id ${CYAN}${entity.device_id}${db} not found processing event:`);
+                return
+              }
+              device_id = device.id;
             }
             this.hassStates.set(response.event.data.new_state.entity_id, response.event.data.new_state);
-            this.emit('event', device.id, entity.entity_id, response.event.data.old_state, response.event.data.new_state);
+            this.emit('event', device_id, entity.entity_id, response.event.data.old_state, response.event.data.new_state);
           } else if (response.id === this.eventsSubscribeId && response.event && response.event.event_type === 'call_service') {
             this.log.debug(`Event ${CYAN}${response.event.event_type}${db} received id ${CYAN}${response.id}${db}`);
             this.emit('call_service');

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -168,7 +168,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
     // Scan individual entities and create Matterbridge devices
     for (const entity of Array.from(this.ha.hassEntities.values())) {
       const [domain, name] = entity.entity_id.split('.');
-      if (!['automation', 'scene', 'script'].includes(domain)) continue;
+      if (!['automation', 'input_boolean', 'scene', 'script'].includes(domain)) continue;
       const entityName = entity.name ?? entity.original_name;
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore


### PR DESCRIPTION
Hey again 👋  Cool to see the developments for HA support.  I have some `input_boolean` "helpers" that I wasn't able to add, and I see how this is structured mainly around devices.  Related: https://github.com/Luligu/matterbridge-hass/discussions/8

This adds support for the domain, then for `state_changed` events with no device_id, it uses the entity_id as the key.  This seems to match how the other individual entities are stored in platform.ts.