### PR TITLE
Release 0.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ TODO.md
 temp
 jest
 ts_homeassistant.json
+certificates/ubuntuToken

--- a/.npmignore
+++ b/.npmignore
@@ -170,3 +170,4 @@ temp
 tsconfig.production.json
 jest
 mock
+certificates/ubuntuToken

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ If you like this project and find it useful, please consider giving it a star on
 - [homeassistant]: Typed HassWebSocketResponses and HassWebSocketMessages.
 - [homeassistant]: Added subscribe() and Jest test.
 - [homeassistant]: Added unsubscribe() and Jest test.
+- [binary_sensor]: Added domain binary_sensor with deviceClass 'garage_door'. It creates a contactSensor with BooleanState cluster.
+- [binary_sensor]: Added domain binary_sensor with deviceClass 'window'. It creates a contactSensor with BooleanState cluster.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@ Since release 0.1.0:
 
 ### Added
 
-- [homeassistant]: Typed HassWebSocketResponses and HassWebSocketMessages.
+- [homeassistant]: Typed HassWebSocketResponses and HassWebSocketRequests.
 - [homeassistant]: Added subscribe() and Jest test.
 - [homeassistant]: Added unsubscribe() and Jest test.
 - [binary_sensor]: Added domain binary_sensor with deviceClass 'garage_door'. It creates a contactSensor with BooleanState cluster.
 - [binary_sensor]: Added domain binary_sensor with deviceClass 'window'. It creates a contactSensor with BooleanState cluster.
-- [jest]: Added real test to test the HomeAssistant api.
+- [jest]: Added real Jest test to test the HomeAssistant api with a real Home Assistant setup.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ If you like this project and find it useful, please consider giving it a star on
   <img src="bmc-button.svg" alt="Buy me a coffee" width="120">
 </a>
 
+## [0.1.2] - 2025-06-??
+
+### Added
+
+### Changed
+
+### Fixed
+
+<a href="https://www.buymeacoffee.com/luligugithub">
+  <img src="bmc-button.svg" alt="Buy me a coffee" width="80">
+</a>
+
 ## [0.1.1] - 2025-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 - [homeassistant]: Typed HassWebSocketResponses and HassWebSocketMessages.
 - [homeassistant]: Added subscribe() and Jest test.
+- [homeassistant]: Added unsubscribe() and Jest test.
 
 ### Changed
 
@@ -40,7 +41,7 @@ If you like this project and find it useful, please consider giving it a star on
 ### Fixed
 
 - [reconnect]: Added missed call to fetchData and subscribe on reconnect.
-- [startup]: Added correct value for BooleanState cluster to avoid controller alarms.
+- [startup]: Added the value from state for BooleanState cluster to avoid controller alarms.
 
 <a href="https://www.buymeacoffee.com/luligugithub">
   <img src="bmc-button.svg" alt="Buy me a coffee" width="80">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ If you like this project and find it useful, please consider giving it a star on
   <img src="bmc-button.svg" alt="Buy me a coffee" width="120">
 </a>
 
-## [0.1.2] - 2025-06-??
+## Breaking changes
+
+Since release 0.1.0:
+
+- the config parameters individualEntityWhiteList and individualEntityBlackList have been removed. Use the normal white and black lists.
+- the config serialPostfix has been changed to postfix.
+
+## [0.1.2] - 2025-06-06
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ If you like this project and find it useful, please consider giving it a star on
 
 ### Added
 
+- [homeassistant]: Typed HassWebSocketResponses and HassWebSocketMessages.
+- [homeassistant]: Added subscribe() and Jest test.
+
 ### Changed
+
+- [config]: Enhanced reconnect config description and set minimum value to 30 secs for reconnectTimeout.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Since release 0.1.0:
 - the config parameters individualEntityWhiteList and individualEntityBlackList have been removed. Use the normal white and black lists.
 - the config serialPostfix has been changed to postfix.
 
-## [0.1.2] - 2025-06-06
+## [0.1.2] - 2025-06-07
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ If you like this project and find it useful, please consider giving it a star on
 - [homeassistant]: Added unsubscribe() and Jest test.
 - [binary_sensor]: Added domain binary_sensor with deviceClass 'garage_door'. It creates a contactSensor with BooleanState cluster.
 - [binary_sensor]: Added domain binary_sensor with deviceClass 'window'. It creates a contactSensor with BooleanState cluster.
+- [jest]: Added real test to test the HomeAssistant api.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,17 @@ Features:
 
 ## Supported sensors:
 
-| Domain        | Supported state class | Supported device class                                    |
-| ------------- | --------------------- | --------------------------------------------------------- |
-| sensor        | measurement           | temperature, humidity, pressure, illuminance              |
-| binary_sensor |                       | door, vibration, motion, occupancy, cold, moisture, smoke |
+| Domain        | Supported state class | Supported device class               | Matter device type  |
+| ------------- | --------------------- | ------------------------------------ | ------------------- |
+| sensor        | measurement           | temperature                          | temperatureSensor   |
+| sensor        | measurement           | humidity                             | humiditySensor      |
+| sensor        | measurement           | pressure                             | pressureSensor      |
+| sensor        | measurement           | illuminance                          | lightSensor         |
+| binary_sensor |                       | window, garage_door, door, vibration | contactSensor       |
+| binary_sensor |                       | motion, occupancy                    | occupancySensor     |
+| binary_sensor |                       | cold                                 | waterFreezeDetector |
+| binary_sensor |                       | moisture                             | waterLeakDetector   |
+| binary_sensor |                       | smoke                                | smokeCoAlarm        |
 
 ## Supported individual entities:
 

--- a/matterbridge-hass.schema.json
+++ b/matterbridge-hass.schema.json
@@ -33,12 +33,12 @@
       "type": "string"
     },
     "reconnectTimeout": {
-      "description": "Reconnect timeout in seconds",
+      "description": "Reconnect timeout in seconds (minimum 30 seconds). If the connection is lost, the plugin will try to reconnect after this timeout.",
       "type": "number",
       "default": 60
     },
     "reconnectRetries": {
-      "description": "Number of times to try to reconnect before giving up",
+      "description": "Number of times to try to reconnect before giving up. Set to 0 for no reconnects.",
       "type": "number",
       "default": 10
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge-hass",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-hass",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "node-ansi-logger": "3.0.1",
@@ -66,9 +66,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.3.tgz",
-      "integrity": "sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
+      "integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -117,13 +117,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.3.tgz",
-      "integrity": "sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
+      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.3",
+        "@babel/parser": "^7.27.5",
         "@babel/types": "^7.27.3",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -233,23 +233,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.4.tgz",
-      "integrity": "sha512-Y+bO6U+I7ZKaM5G5rDUZiYfUvQPUibYmAFe7EnKdnKBbVXDZxvp+MWOH5gYciY0EPk4EScsuFMQBbEfpdRKSCQ==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.27.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.4.tgz",
-      "integrity": "sha512-BRmLHGwpUqLFR2jzx9orBuX/ABDkj2jLKOXrHDTN2aOKL+jFDDKaRNo9nyYsIl9h/UE/7lMKdDjKQQyxKKDZ7g==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -546,9 +546,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
-      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1370,9 +1370,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -1434,9 +1434,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2089,9 +2089,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001720",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
-      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
+      "version": "1.0.30001721",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
+      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
       "dev": true,
       "funding": [
         {
@@ -2351,9 +2351,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.162",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.162.tgz",
-      "integrity": "sha512-hQA+Zb5QQwoSaXJWEAGEw1zhk//O7qDzib05Z4qTqZfNju/FAkrm5ZInp0JbTp4Z18A6bilopdZWEYrFSsfllA==",
+      "version": "1.5.165",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
+      "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
       "dev": true,
       "license": "ISC"
     },
@@ -2542,9 +2542,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.12.0.tgz",
-      "integrity": "sha512-J6zmDp8WiQ9tyvYXE+3RFy7/+l4hraWLzmsabYXyehkmmDd36qV4VQFc7XzcsD8C1PTNt646MSx25bO1mdd9Yw==",
+      "version": "28.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.13.0.tgz",
+      "integrity": "sha512-4AuBcFWOriOeEqy6s4Zup/dQ7E1EPTyyfDaMYmM2YP9xEWPWwK3yYifH1dzY6aHRvyx7y53qMSIyT5s+jrorsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-hass",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Matterbridge hass plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -37,6 +37,7 @@ import {
   occupancySensor,
   onOffLight,
   onOffOutlet,
+  pressureSensor,
   smokeCoAlarm,
   temperatureSensor,
   thermostatDevice,
@@ -171,7 +172,7 @@ export const hassDomainAttributeConverter: { domain: string; withAttribute: stri
 export const hassDomainSensorsConverter: { domain: string; withStateClass: string; withDeviceClass: string; deviceType: DeviceTypeDefinition; clusterId: ClusterId; attribute: string; converter: any }[] = [
     { domain: 'sensor',     withStateClass: 'measurement',  withDeviceClass: 'temperature',   deviceType: temperatureSensor,  clusterId: TemperatureMeasurement.Cluster.id,      attribute: 'measuredValue', converter: (value: number) => (isValidNumber(value, -100, 100) ? Math.round(value * 100) : null) },
     { domain: 'sensor',     withStateClass: 'measurement',  withDeviceClass: 'humidity',      deviceType: humiditySensor,     clusterId: RelativeHumidityMeasurement.Cluster.id, attribute: 'measuredValue', converter: (value: number) => (isValidNumber(value, 0, 100) ? Math.round(value * 100) : null) },
-    { domain: 'sensor',     withStateClass: 'measurement',  withDeviceClass: 'pressure',      deviceType: temperatureSensor,  clusterId: PressureMeasurement.Cluster.id,         attribute: 'measuredValue', converter: (value: number) => (isValidNumber(value) ? Math.round(value) : null) },
+    { domain: 'sensor',     withStateClass: 'measurement',  withDeviceClass: 'pressure',      deviceType: pressureSensor,     clusterId: PressureMeasurement.Cluster.id,         attribute: 'measuredValue', converter: (value: number) => (isValidNumber(value) ? Math.round(value) : null) },
     { domain: 'sensor',     withStateClass: 'measurement',  withDeviceClass: 'illuminance',   deviceType: lightSensor,        clusterId: IlluminanceMeasurement.Cluster.id,      attribute: 'measuredValue', converter: (value: number) => (isValidNumber(value) ? Math.round(Math.max(Math.min(10000 * Math.log10(value), 0xfffe), 0)) : null) },
   ];
 
@@ -179,7 +180,9 @@ export const hassDomainSensorsConverter: { domain: string; withStateClass: strin
 // prettier-ignore
 export const hassDomainBinarySensorsConverter: { domain: string; withDeviceClass: string; deviceType: DeviceTypeDefinition; clusterId: ClusterId; attribute: string; converter: any }[] = [
     // { domain: 'binary_sensor',    withDeviceClass: 'battery',     deviceType: powerSource,          clusterId: PowerSource.Cluster.id,        attribute: 'batChargeLevel',  converter: (value: string) => (value === 'off' ? 0 : 2) },
+    { domain: 'binary_sensor',    withDeviceClass: 'window',      deviceType: contactSensor,        clusterId: BooleanState.Cluster.id,       attribute: 'stateValue',      converter: (value: string) => (value === 'on' ? false : true) },
     { domain: 'binary_sensor',    withDeviceClass: 'door',        deviceType: contactSensor,        clusterId: BooleanState.Cluster.id,       attribute: 'stateValue',      converter: (value: string) => (value === 'on' ? false : true) },
+    { domain: 'binary_sensor',    withDeviceClass: 'garage_door', deviceType: contactSensor,        clusterId: BooleanState.Cluster.id,       attribute: 'stateValue',      converter: (value: string) => (value === 'on' ? false : true) },
     { domain: 'binary_sensor',    withDeviceClass: 'vibration',   deviceType: contactSensor,        clusterId: BooleanState.Cluster.id,       attribute: 'stateValue',      converter: (value: string) => (value === 'on' ? false : true) },
     { domain: 'binary_sensor',    withDeviceClass: 'cold',        deviceType: waterFreezeDetector,  clusterId: BooleanState.Cluster.id,       attribute: 'stateValue',      converter: (value: string) => (value === 'on' ? true : false) },
     { domain: 'binary_sensor',    withDeviceClass: 'moisture',    deviceType: waterLeakDetector,    clusterId: BooleanState.Cluster.id,       attribute: 'stateValue',      converter: (value: string) => (value === 'on' ? true : false) },

--- a/src/homeAssistant.real.test.ts
+++ b/src/homeAssistant.real.test.ts
@@ -55,8 +55,6 @@ describe('HomeAssistant real test on ubuntu', () => {
   let services_response: HassServices = {} as HassServices;
   let config_response: HassConfig = {} as HassConfig;
 
-  if (!accessToken) return;
-
   beforeAll(async () => {
     //
   });
@@ -72,6 +70,12 @@ describe('HomeAssistant real test on ubuntu', () => {
   afterAll(async () => {
     //
   });
+
+  it('should have at least one test', () => {
+    expect(wsUrl).toBeDefined();
+  });
+
+  if (!accessToken) return;
 
   it('should create an instance of HomeAssistant', () => {
     homeAssistant = new HomeAssistant(wsUrl, accessToken);

--- a/src/homeAssistant.real.test.ts
+++ b/src/homeAssistant.real.test.ts
@@ -1,0 +1,227 @@
+// Home Assistant Real WebSocket Client Tests
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { jest } from '@jest/globals';
+import fs from 'node:fs';
+import path from 'node:path';
+import { AnsiLogger, LogLevel } from 'matterbridge/logger';
+
+import { HassArea, HassConfig, HassDevice, HassEntity, HassServices, HassState, HomeAssistant } from './homeAssistant';
+
+let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
+let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+let consoleDebugSpy: jest.SpiedFunction<typeof console.log>;
+let consoleInfoSpy: jest.SpiedFunction<typeof console.log>;
+let consoleWarnSpy: jest.SpiedFunction<typeof console.log>;
+let consoleErrorSpy: jest.SpiedFunction<typeof console.log>;
+const debug = false; // Set to true to enable debug logging
+
+if (!debug) {
+  loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
+  consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {});
+  consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation((...args: any[]) => {});
+  consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation((...args: any[]) => {});
+  consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: any[]) => {});
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {});
+} else {
+  loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
+  consoleLogSpy = jest.spyOn(console, 'log');
+  consoleDebugSpy = jest.spyOn(console, 'debug');
+  consoleInfoSpy = jest.spyOn(console, 'info');
+  consoleWarnSpy = jest.spyOn(console, 'warn');
+  consoleErrorSpy = jest.spyOn(console, 'error');
+}
+
+let accessToken: string | null = null;
+try {
+  accessToken = fs.readFileSync(path.join('certificates', 'ubuntuToken'), 'utf8').trim();
+} catch (error) {
+  accessToken = null;
+}
+
+describe('HomeAssistant real test on ubuntu', () => {
+  let homeAssistant: HomeAssistant;
+  const wsUrl = 'ws://ubuntu:8123';
+  let subscriptionId = 0;
+  const testEntityId = 'light.virtual_light';
+
+  let device_registry_response: HassDevice[] = [];
+  let entity_registry_response: HassEntity[] = [];
+  let area_registry_response: HassArea[] = [];
+  let states_response: HassState[] = [];
+  let services_response: HassServices = {} as HassServices;
+  let config_response: HassConfig = {} as HassConfig;
+
+  if (!accessToken) return;
+
+  beforeAll(async () => {
+    //
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    //
+  });
+
+  afterAll(async () => {
+    //
+  });
+
+  it('should create an instance of HomeAssistant', () => {
+    homeAssistant = new HomeAssistant(wsUrl, accessToken);
+    expect(homeAssistant).toBeDefined();
+    expect(homeAssistant.wsUrl).toBe(wsUrl);
+    expect(homeAssistant.wsAccessToken).toBe(accessToken);
+    expect((homeAssistant as any).reconnectTimeoutTime).toBe(60 * 1000);
+    expect((homeAssistant as any).reconnectRetries).toBe(10);
+    expect(homeAssistant).toBeInstanceOf(HomeAssistant);
+  });
+
+  it('should establish a WebSocket connection to Home Assistant', async () => {
+    let opened = false;
+    homeAssistant.once('socket_opened', () => {
+      opened = true;
+    });
+
+    await new Promise<void>((resolve) => {
+      homeAssistant.once('connected', () => {
+        resolve();
+      });
+      homeAssistant.connect();
+    });
+
+    expect(opened).toBe(true);
+    expect(homeAssistant.connected).toBe(true);
+    expect(homeAssistant.ws).not.toBeNull();
+    expect((homeAssistant as any).pingInterval).not.toBeNull();
+    expect((homeAssistant as any).pingTimeout).toBeNull();
+    expect((homeAssistant as any).reconnectTimeout).toBeNull();
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Connecting to Home Assistant on ${homeAssistant.wsUrl}...`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, `WebSocket connection established`);
+  });
+
+  it('should get the devices from Home Assistant', async () => {
+    device_registry_response = await homeAssistant.fetch('config/device_registry/list');
+    expect(device_registry_response.length).toBeGreaterThan(0);
+  });
+
+  it('should get the entities asyncronously from Home Assistant', async () => {
+    entity_registry_response = await homeAssistant.fetch('config/entity_registry/list');
+    expect(entity_registry_response.length).toBeGreaterThan(0);
+  });
+
+  it('should get the areas asyncronously from Home Assistant', async () => {
+    area_registry_response = await homeAssistant.fetch('config/area_registry/list');
+    expect(area_registry_response.length).toBeGreaterThan(0);
+  });
+
+  it('should get the states asyncronously from Home Assistant', async () => {
+    states_response = await homeAssistant.fetch('get_states');
+    expect(states_response.length).toBeGreaterThan(0);
+  });
+
+  it('should get the config asyncronously from Home Assistant', async () => {
+    config_response = await homeAssistant.fetch('get_config');
+    expect(typeof config_response).toBe('object');
+  });
+
+  it('should get the services asyncronously from Home Assistant', async () => {
+    services_response = await homeAssistant.fetch('get_services');
+    expect(typeof services_response).toBe('object');
+  });
+
+  it('should fetch initial data from Home Assistant', async () => {
+    await expect(homeAssistant.fetchData()).resolves.toBeUndefined();
+  });
+
+  it('should subscribe to Home Assistant', async () => {
+    subscriptionId = await homeAssistant.subscribe();
+    expect(subscriptionId).toBe(13);
+  });
+
+  it('should fail to get fetch from Home Assistant', async () => {
+    await expect(homeAssistant.fetch('notvalid')).rejects.toThrow('Unknown command.');
+  });
+
+  it('should call_service for domain light with turn_on to Home Assistant', async () => {
+    const result = await homeAssistant.callService('light', 'turn_on', testEntityId);
+    expect(result).toBeDefined();
+    expect(result.context).toBeDefined();
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for state update
+    expect(homeAssistant.hassStates.get(testEntityId)?.state).toBe('on');
+  });
+
+  it('should call_service for domain light with brightness 255 to Home Assistant', async () => {
+    const result = await homeAssistant.callService('light', 'turn_on', testEntityId, { brightness: 255 });
+    expect(result).toBeDefined();
+    expect(result.context).toBeDefined();
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for state update
+    expect(homeAssistant.hassStates.get(testEntityId)?.attributes.brightness).toBe(255);
+  });
+
+  it('should call_service for domain light with brightness 10 to Home Assistant', async () => {
+    const result = await homeAssistant.callService('light', 'turn_on', testEntityId, { brightness: 10 });
+    expect(result).toBeDefined();
+    expect(result.context).toBeDefined();
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for state update
+    expect(homeAssistant.hassStates.get(testEntityId)?.attributes.brightness).toBe(10);
+  });
+
+  it('should call_service for domain light with turn_off to Home Assistant', async () => {
+    const result = await homeAssistant.callService('light', 'turn_off', testEntityId);
+    expect(result).toBeDefined();
+    expect(result.context).toBeDefined();
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for state update
+    expect(homeAssistant.hassStates.get(testEntityId)?.state).toBe('off');
+  });
+
+  it('should fail to call_service to Home Assistant with a not valid domain', async () => {
+    await expect(homeAssistant.callService('notadomain', 'turn_on', testEntityId)).rejects.toThrow('Service notadomain.turn_on not found.');
+  });
+
+  it('should fail to call_service to Home Assistant with a not valid service', async () => {
+    await expect(homeAssistant.callService('light', 'notvalid', testEntityId)).rejects.toThrow('Service light.notvalid not found.');
+  });
+
+  it('should fail to call_service to Home Assistant with a not valid entity', async () => {
+    await expect(homeAssistant.callService('light', 'turn_on', 'notvalid')).rejects.toThrow("not a valid value for dictionary value @ data['target']['entity_id']. Got 'notvalid'");
+  });
+
+  it('should unsubscribe to Home Assistant', async () => {
+    await expect(homeAssistant.unsubscribe(subscriptionId)).resolves.toBeUndefined();
+  });
+
+  it('should unsubscribe to Home Assistant and fail', async () => {
+    await expect(homeAssistant.unsubscribe(1)).rejects.toThrow('Subscription not found.');
+  });
+
+  it('should close the WebSocket connection to Home Assistant', async () => {
+    let closed = false;
+    homeAssistant.on('socket_closed', () => {
+      closed = true;
+    });
+
+    await new Promise<void>((resolve) => {
+      homeAssistant.on('disconnected', () => {
+        resolve();
+      });
+      homeAssistant.close();
+    });
+
+    expect(closed).toBe(true);
+    expect(homeAssistant.connected).toBe(false);
+    expect(homeAssistant.ws).toBeNull();
+    expect((homeAssistant as any).pingInterval).toBeNull();
+    expect((homeAssistant as any).pingTimeout).toBeNull();
+    expect((homeAssistant as any).reconnectTimeout).toBeNull();
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Closing Home Assistant connection...`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Home Assistant connection closed`);
+    homeAssistant.removeAllListeners(); // Remove all listeners to avoid memory leaks
+  });
+});

--- a/src/homeAssistant.real.test.ts
+++ b/src/homeAssistant.real.test.ts
@@ -115,27 +115,27 @@ describe('HomeAssistant real test on ubuntu', () => {
     expect(device_registry_response.length).toBeGreaterThan(0);
   });
 
-  it('should get the entities asyncronously from Home Assistant', async () => {
+  it('should get the entities from Home Assistant', async () => {
     entity_registry_response = await homeAssistant.fetch('config/entity_registry/list');
     expect(entity_registry_response.length).toBeGreaterThan(0);
   });
 
-  it('should get the areas asyncronously from Home Assistant', async () => {
+  it('should get the areas from Home Assistant', async () => {
     area_registry_response = await homeAssistant.fetch('config/area_registry/list');
     expect(area_registry_response.length).toBeGreaterThan(0);
   });
 
-  it('should get the states asyncronously from Home Assistant', async () => {
+  it('should get the states from Home Assistant', async () => {
     states_response = await homeAssistant.fetch('get_states');
     expect(states_response.length).toBeGreaterThan(0);
   });
 
-  it('should get the config asyncronously from Home Assistant', async () => {
+  it('should get the config  from Home Assistant', async () => {
     config_response = await homeAssistant.fetch('get_config');
     expect(typeof config_response).toBe('object');
   });
 
-  it('should get the services asyncronously from Home Assistant', async () => {
+  it('should get the services from Home Assistant', async () => {
     services_response = await homeAssistant.fetch('get_services');
     expect(typeof services_response).toBe('object');
   });
@@ -149,7 +149,7 @@ describe('HomeAssistant real test on ubuntu', () => {
     expect(subscriptionId).toBe(13);
   });
 
-  it('should fail to get fetch from Home Assistant', async () => {
+  it('should fail to fetch from Home Assistant', async () => {
     await expect(homeAssistant.fetch('notvalid')).rejects.toThrow('Unknown command.');
   });
 

--- a/src/homeAssistant.test.ts
+++ b/src/homeAssistant.test.ts
@@ -835,7 +835,7 @@ describe('HomeAssistant with ssl', () => {
     homeAssistant.once('error', (error) => {
       expect(error).toBe('WebSocket response error: undefined');
     });
-    await expect(homeAssistant.fetch('noresponse')).rejects.toThrow('Fetch api noresponse id 3 did not complete before the timeout');
+    await expect(homeAssistant.fetch('noresponse')).rejects.toThrow('Fetch type noresponse id 3 did not complete before the timeout');
     homeAssistant.responseTimeout = 10000; // Restore the default timeout
   });
 

--- a/src/homeAssistant.test.ts
+++ b/src/homeAssistant.test.ts
@@ -14,7 +14,7 @@ import { WebSocket, WebSocketServer } from 'ws';
 import { AnsiLogger, CYAN, db, LogLevel } from 'matterbridge/logger';
 import { wait } from 'matterbridge/utils';
 
-import { HassArea, HassConfig, HassDevice, HassEntity, HassServices, HassState, HomeAssistant } from './homeAssistant'; // Adjust the import path as necessary
+import { HassArea, HassConfig, HassDevice, HassEntity, HassServices, HassState, HassWebSocketResponseSubscribeEvents, HomeAssistant } from './homeAssistant'; // Adjust the import path as necessary
 
 let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
 let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
@@ -701,7 +701,15 @@ describe('HomeAssistant with ssl', () => {
         } else if (msg.type === 'get_states') {
           socket.send(JSON.stringify({ id: msg.id, type: 'result', success: true, result: [] }));
         } else if (msg.type === 'subscribe_events') {
-          socket.send(JSON.stringify({ id: msg.id, type: 'result', success: true }));
+          if (msg.event_type === 'notanevent') {
+            socket.send(JSON.stringify({ id: msg.id, type: 'result', success: false, error: { code: 'notanevent', message: 'Not a valid event type' } }));
+          } else if (msg.event_type === 'notajson') {
+            socket.send('not a json');
+          } else if (msg.event_type === 'noresponse') {
+            // Do not send any response
+          } else {
+            socket.send(JSON.stringify({ id: msg.id, type: 'result', success: true } as HassWebSocketResponseSubscribeEvents));
+          }
         } else if (msg.type === 'call_service' && msg.domain === 'notajson') {
           socket.send('not a json');
         } else if (msg.type === 'call_service' && msg.domain === 'nosuccess') {
@@ -895,7 +903,7 @@ describe('HomeAssistant with ssl', () => {
     homeAssistant.removeAllListeners(); // Remove all listeners to avoid memory leaks
   });
 
-  it('should connectAsync to Home Assistant with ssl and rejectUnauthorized=false', async () => {
+  it('should connect to Home Assistant with ssl and rejectUnauthorized=false', async () => {
     homeAssistant = new HomeAssistant('wss://localhost:8123', accessToken, undefined, undefined, undefined, false);
     await homeAssistant.connect();
     expect(homeAssistant.connected).toBe(true);
@@ -907,7 +915,7 @@ describe('HomeAssistant with ssl', () => {
     expect(homeAssistant.hassConfig).toBeNull();
   });
 
-  it('should not connectAsync a second time to Home Assistant with ssl', async () => {
+  it('should not connect a second time to Home Assistant with ssl', async () => {
     expect(homeAssistant.connected).toBe(true);
     await expect(homeAssistant.connect()).rejects.toThrow('Already connected to Home Assistant');
   });
@@ -931,19 +939,38 @@ describe('HomeAssistant with ssl', () => {
 
   it('should subscribe to Home Assistant', async () => {
     expect(homeAssistant.connected).toBe(true);
-    await homeAssistant.subscribe();
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, 'Subscribing to events...');
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, 'Subscribed to events.');
+    const subscriptionId = await homeAssistant.subscribe();
+    expect(loggerLogSpy).toHaveBeenCalledWith(
+      LogLevel.DEBUG,
+      `Subscribing to ${CYAN}all events${db} with id ${CYAN}${subscriptionId}${db} and timeout ${CYAN}${(homeAssistant as any)._responseTimeout}${db} ms ...`,
+    );
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, `Subscribed successfully with id ${CYAN}${subscriptionId}${db}`);
   });
 
-  it('should subscribe to Home Assistant and fail', async () => {
+  it('should subscribe to Home Assistant and fail for event not valid', async () => {
     expect(homeAssistant.connected).toBe(true);
-    jest.spyOn(homeAssistant, 'fetch').mockImplementationOnce(() => {
-      return Promise.reject(new Error('Failed to fetch data'));
-    });
-    await homeAssistant.subscribe();
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, 'Subscribing to events...');
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.ERROR, 'Error subscribing to events: Error: Failed to fetch data');
+    await expect(homeAssistant.subscribe('notanevent')).rejects.toThrow('Not a valid event type');
+  });
+
+  it('should subscribe to Home Assistant and fail for Unexpected token', async () => {
+    expect(homeAssistant.connected).toBe(true);
+    await expect(homeAssistant.subscribe('notajson')).rejects.toThrow();
+  });
+
+  it('should subscribe to Home Assistant and fail not connected', async () => {
+    expect(homeAssistant.connected).toBe(true);
+    homeAssistant.connected = false; // Simulate not connected
+    await expect(homeAssistant.subscribe()).rejects.toThrow('Subscribe error: not connected to Home Assistant');
+    homeAssistant.connected = true; // Restore connection state
+  });
+
+  it('should subscribe to Home Assistant and fail for timeout', async () => {
+    expect(homeAssistant.connected).toBe(true);
+    homeAssistant.responseTimeout = 1; // Set a short timeout for testing
+    await expect(homeAssistant.subscribe('noresponse')).rejects.toThrow(
+      `Subscribe event noresponse id ${(homeAssistant as any).requestId - 1} did not complete before the timeout`,
+    );
+    homeAssistant.responseTimeout = 5000; // Restore default timeout
   });
 
   it('should close with Home Assistant with ssl', async () => {
@@ -952,6 +979,13 @@ describe('HomeAssistant with ssl', () => {
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'Closing Home Assistant connection...');
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'Home Assistant connection closed');
     homeAssistant.removeAllListeners(); // Remove all listeners to avoid memory leaks
+    expect(homeAssistant.connected).toBe(false);
+  });
+
+  it('should subscribe to Home Assistant and fail ws not opened', async () => {
+    homeAssistant.connected = true; // Ensure connected state
+    await expect(homeAssistant.subscribe()).rejects.toThrow('Subscribe error: WebSocket not open');
+    homeAssistant.connected = false; // Restore connection state
   });
 
   it('should not connect if wsUrl is wss:// and certificate are not present', async () => {

--- a/src/homeAssistant.test.ts
+++ b/src/homeAssistant.test.ts
@@ -1,6 +1,6 @@
-/* eslint-disable jest/no-conditional-expect */
 // Home Assistant WebSocket Client Tests
 
+/* eslint-disable jest/no-conditional-expect */
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -14,7 +14,7 @@ import { WebSocket, WebSocketServer } from 'ws';
 import { AnsiLogger, CYAN, db, LogLevel } from 'matterbridge/logger';
 import { wait } from 'matterbridge/utils';
 
-import { HassArea, HassConfig, HassDevice, HassEntity, HassServices, HassState, HassWebSocketResponseResult, HomeAssistant } from './homeAssistant'; // Adjust the import path as necessary
+import { HassArea, HassConfig, HassDevice, HassEntity, HassServices, HassState, HassWebSocketResponseResult, HomeAssistant } from './homeAssistant';
 
 let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
 let consoleLogSpy: jest.SpiedFunction<typeof console.log>;

--- a/src/homeAssistant.ts
+++ b/src/homeAssistant.ts
@@ -5,7 +5,7 @@
  * @file src\homeAssistant.ts
  * @author Luca Liguori
  * @date 2024-09-14
- * @version 1.0.2
+ * @version 1.1.0
  *
  * Copyright 2024, 2025, 2026 Luca Liguori.
  *
@@ -119,12 +119,12 @@ export interface HassState {
   last_changed: string;
   last_reported: string;
   last_updated: string;
-  attributes: HassStateAttributes & HassStateLightAttributes & HassStateClimateAttributes & HassStateFanAttributes & Record<string, HomeAssistantPrimitive>;
+  attributes: HassStateAttributes & HassStateLightAttributes & HassStateClimateAttributes & HassStateFanAttributes;
   context: HassContext;
 }
 
 /**
- * Interface representing the attributes of a Home Assistant entity's state.
+ * Interface representing the generic attributes of a Home Assistant entity's state.
  */
 export interface HassStateAttributes {
   friendly_name?: string;
@@ -165,21 +165,28 @@ export interface HassStateLightAttributes {
  * Interface representing the attributes of a Home Assistant fan entity's state.
  */
 export interface HassStateFanAttributes {
-  preset_modes?: string[]; // List of supported fan modes (e.g., "low", "medium", "high", "auto")
-  preset_mode?: string; // Current preset mode of the fan (e.g., "auto") but also the state of the fan entity (e.g., "on", "off")
+  preset_modes?: ('auto' | 'low' | 'medium' | 'high')[]; // List of supported fan modes
+  preset_mode?: 'auto' | 'low' | 'medium' | 'high' | null; // Current preset mode of the fan (e.g., "auto") but also the state of the fan entity
   percentage?: number; // Current speed setting
-  percentage_step?: number; // Current speed of the fan entity
+  percentage_step?: number; // Current step speed setting of the fan entity
 }
 
 /**
  * Interface representing the attributes of a Home Assistant climate entity's state.
  */
 export interface HassStateClimateAttributes {
-  hvac_modes?: string[]; // List of supported HVAC modes (e.g., "off", "heat", "cool", "heat_cool", "auto", "dry", "fan_only")
-  temperature?: number; // Target temperature setting
-  current_temperature?: number; // Current temperature of the climate entity
-  fan_modes?: string[]; // List of supported fan modes (e.g., "auto", "low", "medium", "high")
-  fan_mode?: string | null; // Fan mode (e.g., "auto")
+  hvac_modes?: ('off' | 'heat' | 'cool' | 'heat_cool' | 'auto' | 'dry' | 'fan_only')[]; // List of supported HVAC modes
+  hvac_mode?: 'off' | 'heat' | 'cool' | 'heat_cool' | 'auto' | 'dry' | 'fan_only' | null; // Current HVAC mode but also the state of the climate entity
+  preset_modes?: ('none' | 'eco' | 'away' | 'boost' | 'comfort' | 'home' | 'sleep' | 'activity')[]; // List of supported preset modes
+  preset_mode?: 'none' | 'eco' | 'away' | 'boost' | 'comfort' | 'home' | 'sleep' | 'activity' | null; // Current preset mode
+  fan_modes?: ('on' | 'off' | 'auto' | 'low' | 'medium' | 'high' | 'top' | 'middle' | 'focus' | 'diffuse')[]; // List of supported fan modes
+  fan_mode?: 'on' | 'off' | 'auto' | 'low' | 'medium' | 'high' | 'top' | 'middle' | 'focus' | 'diffuse' | null; // Fan mode
+  current_temperature?: number | null; // Current temperature of the climate entity
+  temperature?: number | null; // Target temperature setting for the climate entity (not in heat_cool thermostats)
+  target_temp_high?: number | null; // Target high temperature setting (for heat_cool thermostats)
+  target_temp_low?: number | null; // Target low temperature setting (for heat_cool thermostats)
+  min_temp?: number | null; // Minimum temperature setting
+  max_temp?: number | null; // Maximum temperature setting
 }
 
 /**

--- a/src/homeAssistant.ts
+++ b/src/homeAssistant.ts
@@ -835,13 +835,12 @@ export class HomeAssistant extends EventEmitter {
   /**
    * Sends a request to Home Assistant and waits for a response.
    *
-   * @param {string} api - The type of request to send.
+   * @param {string} type - The type of request to send.
    * @returns {Promise<any>} - A Promise that resolves with the response from Home Assistant or rejects with an error.
-   * @throws {Error} - Throws an error if not connected to Home Assistant or if the WebSocket is not open.
    *
    * @example
    * // Example usage:
-   * fetchAsync('get_states')
+   * fetch('get_states')
    *   .then(response => {
    *     console.log('Received response:', response);
    *   })
@@ -850,7 +849,7 @@ export class HomeAssistant extends EventEmitter {
    *   });
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fetch(api: string): Promise<any> {
+  fetch(type: string): Promise<any> {
     return new Promise((resolve, reject) => {
       if (!this.connected) {
         return reject(new Error('Fetch error: not connected to Home Assistant'));
@@ -863,7 +862,7 @@ export class HomeAssistant extends EventEmitter {
 
       const timer = setTimeout(() => {
         this.ws?.removeEventListener('message', handleMessage);
-        return reject(new Error(`Fetch api ${api} id ${requestId} did not complete before the timeout`));
+        return reject(new Error(`Fetch type ${type} id ${requestId} did not complete before the timeout`));
       }, this._responseTimeout).unref();
 
       const handleMessage = (event: WebSocket.MessageEvent) => {
@@ -887,8 +886,8 @@ export class HomeAssistant extends EventEmitter {
 
       this.ws.addEventListener('message', handleMessage);
 
-      this.log.debug(`Fetching async ${CYAN}${api}${db} with id ${CYAN}${requestId}${db} and timeout ${CYAN}${this._responseTimeout}${db} ms ...`);
-      this.ws.send(JSON.stringify({ id: requestId, type: api } as HassWebSocketMessageFetch));
+      this.log.debug(`Fetching async ${CYAN}${type}${db} with id ${CYAN}${requestId}${db} and timeout ${CYAN}${this._responseTimeout}${db} ms ...`);
+      this.ws.send(JSON.stringify({ id: requestId, type: type } as HassWebSocketMessageFetch));
     });
   }
 
@@ -900,7 +899,6 @@ export class HomeAssistant extends EventEmitter {
    * @param {string} entityId - The ID of the entity to target with the command.
    * @param {Record<string, any>} [serviceData={}] - Optional additional data to send with the command.
    * @returns {Promise<any>} - A Promise that resolves with the response from Home Assistant or rejects with an error.
-   * @throws {Error} - Throws an error if not connected to Home Assistant or if the WebSocket is not open.
    *
    * @example <caption>Example usage of the callService method.</caption>
    * await this.callService('switch', 'toggle', 'switch.living_room');

--- a/src/homeAssistant.ts
+++ b/src/homeAssistant.ts
@@ -887,7 +887,7 @@ export class HomeAssistant extends EventEmitter {
 
   /**
    * Sends a "subscribe_events" request to Home Assistant and waits for a response.
-   * @param {string} event - The event to subscribe to or all events if not specified.
+   * @param {string | undefined} event - The event to subscribe to or all events if not specified.
    * @returns {Promise<number>} - A Promise that resolves with the subscribe id from Home Assistant or rejects with an error.
    *
    * @example

--- a/src/platform.matter.test.ts
+++ b/src/platform.matter.test.ts
@@ -21,7 +21,8 @@ import { AnsiLogger, CYAN, nf, rs, TimestampFormat, LogLevel, idn, db, or, hk } 
 // Home Assistant Plugin
 import { HomeAssistantPlatform } from './platform';
 import { HassConfig, HassDevice, HassEntity, HassServices, HassState, HomeAssistant } from './homeAssistant';
-import { BooleanState, FanControl, OnOff, SmokeCoAlarm } from 'matterbridge/matter/clusters';
+import { BooleanState, FanControl, OnOff, LevelControl, SmokeCoAlarm, ColorControl, Thermostat } from 'matterbridge/matter/clusters';
+import { MutableDevice } from './mutableDevice';
 
 let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
 let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
@@ -183,6 +184,15 @@ const callServiceSpy = jest
 const setAttributeSpy = jest.spyOn(MatterbridgeEndpoint.prototype, 'setAttribute');
 const updateAttributeSpy = jest.spyOn(MatterbridgeEndpoint.prototype, 'updateAttribute');
 const subscribeAttributeSpy = jest.spyOn(MatterbridgeEndpoint.prototype, 'subscribeAttribute');
+
+const addClusterServerBooleanStateSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerBooleanState');
+const addClusterServerSmokeCoAlarmSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerSmokeCoAlarm');
+const addClusterServerColorTemperatureColorControlSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerColorTemperatureColorControl');
+const addClusterServerColorControlSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerColorControl');
+const addClusterServerAutoModeThermostatSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerAutoModeThermostat');
+const addClusterServerHeatingThermostatSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerHeatingThermostat');
+const addClusterServerCoolingThermostatSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerCoolingThermostat');
+
 MatterbridgeEndpoint.logLevel = LogLevel.DEBUG; // Set the log level for MatterbridgeEndpoint to DEBUG
 
 let haPlatform: HomeAssistantPlatform;
@@ -355,6 +365,164 @@ describe('Matterbridge ' + NAME, () => {
     expect(aggregator.parts.size).toBe(0);
   });
 
+  it('should call onStart and register an Color Temperature Light device', async () => {
+    const lightDevice = {
+      area_id: null,
+      disabled_by: null,
+      entry_type: null,
+      id: 'd80898f83188759ed7329e97df00cc6b',
+      labels: [],
+      name: 'Color Temperature Light',
+      name_by_user: null,
+    } as unknown as HassDevice;
+
+    const lightDeviceEntity = {
+      area_id: null,
+      device_id: lightDevice.id,
+      entity_category: null,
+      entity_id: 'light.light_ct',
+      has_entity_name: true,
+      id: '0b25a337cb83edefb1d310450cc2b0aa',
+      labels: [],
+      name: null,
+      original_name: 'Color Temperature Light',
+    } as unknown as HassEntity;
+
+    const lightDeviceEntityState = {
+      entity_id: lightDeviceEntity.entity_id,
+      state: 'on',
+      attributes: {
+        device_class: 'light',
+        supported_color_modes: ['onoff', 'brightness', 'color_temp'],
+        color_mode: 'color_temp',
+        brightness: 100,
+        color_temp: 200, // Color temperature in mireds
+        min_mireds: 153, // Minimum mireds (6500K)
+        max_mireds: 400, // Maximum mireds (2500K)
+        friendly_name: 'Light Light Ct',
+      },
+    } as unknown as HassState;
+
+    haPlatform.ha.hassDevices.set(lightDevice.id, lightDevice);
+    haPlatform.ha.hassEntities.set(lightDeviceEntity.entity_id, lightDeviceEntity);
+    haPlatform.ha.hassStates.set(lightDeviceEntityState.entity_id, lightDeviceEntityState);
+
+    await haPlatform.onStart('Test reason');
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for async operations to complete
+    expect(mockLog.info).toHaveBeenCalledWith(`Starting platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);
+    expect(mockMatterbridge.addBridgedEndpoint).toHaveBeenCalledTimes(1);
+    expect(haPlatform.matterbridgeDevices.size).toBe(1);
+    expect(haPlatform.matterbridgeDevices.get(lightDevice.id)).toBeDefined();
+    device = haPlatform.matterbridgeDevices.get(lightDevice.id) as MatterbridgeEndpoint;
+    expect(device.construction.status).toBe(Lifecycle.Status.Active);
+    const child = device?.getChildEndpointByName(lightDeviceEntity.entity_id.replace('.', ''));
+    expect(child).toBeDefined();
+    if (!child) return;
+    expect(child.construction.status).toBe(Lifecycle.Status.Active);
+    expect(aggregator.parts.has(device)).toBeTruthy();
+    expect(aggregator.parts.has(device.id)).toBeTruthy();
+    expect(subscribeAttributeSpy).toHaveBeenCalledTimes(0);
+    expect(addClusterServerColorTemperatureColorControlSpy).toHaveBeenCalledWith(lightDeviceEntity.entity_id, 200, 153, 400);
+
+    jest.clearAllMocks();
+    await haPlatform.onConfigure();
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for async updateHandler operations to complete
+    expect(mockLog.debug).toHaveBeenCalledWith(
+      expect.stringContaining(`Configuring state ${CYAN}${lightDeviceEntityState.entity_id}${db} for device ${CYAN}${lightDevice.id}${db}`),
+    );
+    expect(setAttributeSpy).toHaveBeenCalledWith(OnOff.Cluster.id, 'onOff', true, expect.anything());
+    expect(setAttributeSpy).toHaveBeenCalledWith(LevelControl.Cluster.id, 'currentLevel', 100, expect.anything());
+    expect(setAttributeSpy).toHaveBeenCalledWith(ColorControl.Cluster.id, 'colorMode', ColorControl.ColorMode.ColorTemperatureMireds, expect.anything());
+    expect(setAttributeSpy).toHaveBeenCalledWith(ColorControl.Cluster.id, 'colorTemperatureMireds', 200, expect.anything());
+
+    haPlatform.matterbridgeDevices.delete(lightDevice.id);
+    haPlatform.ha.hassDevices.delete(lightDevice.id);
+    haPlatform.ha.hassEntities.delete(lightDeviceEntity.entity_id);
+    haPlatform.ha.hassStates.delete(lightDeviceEntityState.entity_id);
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for async storage number persist operations to complete
+    await device.delete();
+    expect(aggregator.parts.size).toBe(0);
+  });
+
+  it('should call onStart and register an Rgb Light device', async () => {
+    const lightDevice = {
+      area_id: null,
+      disabled_by: null,
+      entry_type: null,
+      id: 'd80898f83188759ed7329e97df00ee6b',
+      labels: [],
+      name: 'Light',
+      name_by_user: null,
+    } as unknown as HassDevice;
+
+    const lightDeviceEntity = {
+      area_id: null,
+      device_id: lightDevice.id,
+      entity_category: null,
+      entity_id: 'light.light',
+      has_entity_name: true,
+      id: '0b25a337cb83edefb1d310450ad2b0aa',
+      labels: [],
+      name: null,
+      original_name: 'Light',
+    } as unknown as HassEntity;
+
+    const lightDeviceEntityState = {
+      entity_id: lightDeviceEntity.entity_id,
+      state: 'on',
+      attributes: {
+        device_class: 'light',
+        supported_color_modes: ['onoff', 'brightness', 'rgb'],
+        color_mode: 'hs',
+        brightness: 100,
+        hs_color: [180, 50], // Hue and Saturation
+        rgb_color: [255, 255, 255],
+        friendly_name: 'Light Light',
+      },
+    } as unknown as HassState;
+
+    haPlatform.ha.hassDevices.set(lightDevice.id, lightDevice);
+    haPlatform.ha.hassEntities.set(lightDeviceEntity.entity_id, lightDeviceEntity);
+    haPlatform.ha.hassStates.set(lightDeviceEntityState.entity_id, lightDeviceEntityState);
+
+    await haPlatform.onStart('Test reason');
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for async operations to complete
+    expect(mockLog.info).toHaveBeenCalledWith(`Starting platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);
+    expect(mockMatterbridge.addBridgedEndpoint).toHaveBeenCalledTimes(1);
+    expect(haPlatform.matterbridgeDevices.size).toBe(1);
+    expect(haPlatform.matterbridgeDevices.get(lightDevice.id)).toBeDefined();
+    device = haPlatform.matterbridgeDevices.get(lightDevice.id) as MatterbridgeEndpoint;
+    expect(device.construction.status).toBe(Lifecycle.Status.Active);
+    const child = device?.getChildEndpointByName(lightDeviceEntity.entity_id.replace('.', ''));
+    expect(child).toBeDefined();
+    if (!child) return;
+    expect(child.construction.status).toBe(Lifecycle.Status.Active);
+    expect(aggregator.parts.has(device)).toBeTruthy();
+    expect(aggregator.parts.has(device.id)).toBeTruthy();
+    expect(subscribeAttributeSpy).toHaveBeenCalledTimes(0);
+    expect(addClusterServerColorControlSpy).toHaveBeenCalledWith(lightDeviceEntity.entity_id, 250, 147, 500);
+
+    jest.clearAllMocks();
+    await haPlatform.onConfigure();
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for async updateHandler operations to complete
+    expect(mockLog.debug).toHaveBeenCalledWith(
+      expect.stringContaining(`Configuring state ${CYAN}${lightDeviceEntityState.entity_id}${db} for device ${CYAN}${lightDevice.id}${db}`),
+    );
+    expect(setAttributeSpy).toHaveBeenCalledWith(OnOff.Cluster.id, 'onOff', true, expect.anything());
+    expect(setAttributeSpy).toHaveBeenCalledWith(LevelControl.Cluster.id, 'currentLevel', 100, expect.anything());
+    expect(setAttributeSpy).toHaveBeenCalledWith(ColorControl.Cluster.id, 'colorMode', ColorControl.ColorMode.CurrentHueAndCurrentSaturation, expect.anything());
+    expect(setAttributeSpy).toHaveBeenCalledWith(ColorControl.Cluster.id, 'currentHue', 127, expect.anything());
+    expect(setAttributeSpy).toHaveBeenCalledWith(ColorControl.Cluster.id, 'currentSaturation', 127, expect.anything());
+
+    haPlatform.matterbridgeDevices.delete(lightDevice.id);
+    haPlatform.ha.hassDevices.delete(lightDevice.id);
+    haPlatform.ha.hassEntities.delete(lightDeviceEntity.entity_id);
+    haPlatform.ha.hassStates.delete(lightDeviceEntityState.entity_id);
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for async storage number persist operations to complete
+    await device.delete();
+    expect(aggregator.parts.size).toBe(0);
+  });
+
   it('should call onStart and register a Fan device', async () => {
     const fanDevice = {
       area_id: null,
@@ -443,6 +611,98 @@ describe('Matterbridge ' + NAME, () => {
     expect(aggregator.parts.size).toBe(0);
   });
 
+  it('should call onStart and register a Climate device', async () => {
+    const climateDevice = {
+      area_id: null,
+      disabled_by: null,
+      entry_type: null,
+      id: 'd80898f83188759ed7329e97df00ee7a',
+      labels: [],
+      name: 'Climate',
+      name_by_user: null,
+    } as unknown as HassDevice;
+
+    const climateDeviceEntity = {
+      area_id: null,
+      device_id: climateDevice.id,
+      entity_category: null,
+      entity_id: 'climate.climate_auto',
+      has_entity_name: true,
+      id: '0b25a337cb83edefb1d310450ad2b0ab',
+      labels: [],
+      name: null,
+      original_name: 'Climate',
+    } as unknown as HassEntity;
+
+    const climateDeviceEntityState = {
+      entity_id: climateDeviceEntity.entity_id,
+      state: 'heat_cool',
+      attributes: { hvac_modes: ['heat_cool'], hvac_mode: 'heat_cool', current_temperature: 20, target_temp_low: 10, target_temp_high: 30, friendly_name: 'Climate Climate auto' },
+    } as unknown as HassState;
+
+    haPlatform.ha.hassDevices.set(climateDevice.id, climateDevice);
+    haPlatform.ha.hassEntities.set(climateDeviceEntity.entity_id, climateDeviceEntity);
+    haPlatform.ha.hassStates.set(climateDeviceEntityState.entity_id, climateDeviceEntityState);
+
+    await haPlatform.onStart('Test reason');
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for async operations to complete
+    expect(mockLog.info).toHaveBeenCalledWith(`Starting platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);
+    expect(mockMatterbridge.addBridgedEndpoint).toHaveBeenCalledTimes(1);
+    expect(haPlatform.matterbridgeDevices.size).toBe(1);
+    expect(haPlatform.matterbridgeDevices.get(climateDevice.id)).toBeDefined();
+    device = haPlatform.matterbridgeDevices.get(climateDevice.id) as MatterbridgeEndpoint;
+    expect(device.construction.status).toBe(Lifecycle.Status.Active);
+    const child = device?.getChildEndpointByName(climateDeviceEntity.entity_id.replace('.', ''));
+    expect(child).toBeDefined();
+    if (!child) return;
+    await child.construction.ready;
+    expect(child.construction.status).toBe(Lifecycle.Status.Active);
+    expect(aggregator.parts.has(device)).toBeTruthy();
+    expect(aggregator.parts.has(device.id)).toBeTruthy();
+    expect(subscribeAttributeSpy).toHaveBeenCalledWith(Thermostat.Cluster.id, 'systemMode', expect.anything(), expect.anything());
+    expect(subscribeAttributeSpy).toHaveBeenCalledWith(Thermostat.Cluster.id, 'occupiedHeatingSetpoint', expect.anything(), expect.anything());
+    expect(subscribeAttributeSpy).toHaveBeenCalledWith(Thermostat.Cluster.id, 'occupiedCoolingSetpoint', expect.anything(), expect.anything());
+    expect(loggerLogSpy).toHaveBeenCalledWith(
+      LogLevel.INFO,
+      expect.stringContaining(`${db}Subscribed endpoint ${or}${child.id}${db}:${or}${child.number}${db} attribute ${hk}Thermostat${db}.${hk}systemMode$Changed${db}`),
+    );
+    expect(loggerLogSpy).toHaveBeenCalledWith(
+      LogLevel.INFO,
+      expect.stringContaining(`${db}Subscribed endpoint ${or}${child.id}${db}:${or}${child.number}${db} attribute ${hk}Thermostat${db}.${hk}occupiedHeatingSetpoint$Changed${db}`),
+    );
+    expect(loggerLogSpy).toHaveBeenCalledWith(
+      LogLevel.INFO,
+      expect.stringContaining(`${db}Subscribed endpoint ${or}${child.id}${db}:${or}${child.number}${db} attribute ${hk}Thermostat${db}.${hk}occupiedCoolingSetpoint$Changed${db}`),
+    );
+
+    jest.clearAllMocks();
+    await haPlatform.onConfigure();
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for async updateHandler operations to complete
+    expect(mockLog.debug).toHaveBeenCalledWith(
+      expect.stringContaining(`Configuring state ${CYAN}${climateDeviceEntityState.entity_id}${db} for device ${CYAN}${climateDevice.id}${db}`),
+    );
+    expect(setAttributeSpy).toHaveBeenCalledWith(Thermostat.Cluster.id, 'systemMode', Thermostat.SystemMode.Auto, expect.anything());
+    expect(setAttributeSpy).toHaveBeenCalledWith(Thermostat.Cluster.id, 'occupiedHeatingSetpoint', 1000, expect.anything());
+    expect(setAttributeSpy).toHaveBeenCalledWith(Thermostat.Cluster.id, 'occupiedCoolingSetpoint', 3000, expect.anything());
+
+    // Simulate a not changed in fan mode and call the event handler
+    await child.act((agent) => agent['thermostat'].events['systemMode$Changed'].emit(Thermostat.SystemMode.Auto, Thermostat.SystemMode.Auto, { ...agent.context, offline: false }));
+    // Simulate a change in fan mode and call the event handler
+    await child.act((agent) => agent['thermostat'].events['systemMode$Changed'].emit(Thermostat.SystemMode.Cool, Thermostat.SystemMode.Auto, { ...agent.context, offline: false }));
+    // Simulate a change in fan mode and call the event handler with wrong parameter
+    await child.act((agent) =>
+      agent['thermostat'].events['systemMode$Changed'].emit(Thermostat.SystemMode.Heat + 1, Thermostat.SystemMode.Auto, { ...agent.context, offline: false }),
+    );
+
+    haPlatform.matterbridgeDevices.delete(climateDevice.id);
+    haPlatform.ha.hassDevices.delete(climateDevice.id);
+    haPlatform.ha.hassEntities.delete(climateDeviceEntity.entity_id);
+    haPlatform.ha.hassStates.delete(climateDeviceEntityState.entity_id);
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for async storage number persist operations to complete
+    await device.delete();
+    expect(aggregator.parts.size).toBe(0);
+  });
+
   it('should call onStart and register a Contact device', async () => {
     const contactDevice = {
       area_id: null,
@@ -493,6 +753,7 @@ describe('Matterbridge ' + NAME, () => {
     expect(aggregator.parts.has(device.id)).toBeTruthy();
     expect(subscribeAttributeSpy).toHaveBeenCalledTimes(0);
     expect(child.getAttribute(BooleanState.Cluster.id, 'stateValue')).toBe(false); // Contact Sensor: true = closed or contact, false = open or no contact
+    expect(addClusterServerBooleanStateSpy).toHaveBeenCalledWith(contactDeviceEntity.entity_id, false);
 
     jest.clearAllMocks();
     await haPlatform.onConfigure();
@@ -569,6 +830,7 @@ describe('Matterbridge ' + NAME, () => {
     expect(aggregator.parts.has(device.id)).toBeTruthy();
     expect(subscribeAttributeSpy).toHaveBeenCalledTimes(0);
     expect(child.getAttribute(BooleanState.Cluster.id, 'stateValue')).toBe(false); // Water Leak Detector: true = leak, false = no leak
+    expect(addClusterServerBooleanStateSpy).toHaveBeenCalledWith(leakDeviceEntity.entity_id, false);
 
     jest.clearAllMocks();
     await haPlatform.onConfigure();
@@ -642,6 +904,8 @@ describe('Matterbridge ' + NAME, () => {
     expect(aggregator.parts.has(device)).toBeTruthy();
     expect(aggregator.parts.has(device.id)).toBeTruthy();
     expect(subscribeAttributeSpy).toHaveBeenCalledTimes(0);
+    expect(child.getAttribute(SmokeCoAlarm.Cluster.id, 'smokeState')).toBe(SmokeCoAlarm.ExpressedState.Normal);
+    expect(addClusterServerSmokeCoAlarmSpy).toHaveBeenCalledWith(smokeDeviceEntity.entity_id, SmokeCoAlarm.ExpressedState.Normal);
 
     jest.clearAllMocks();
     await haPlatform.onConfigure();

--- a/src/platform.matter.test.ts
+++ b/src/platform.matter.test.ts
@@ -150,7 +150,7 @@ const mockConfig = {
 
 const connectSpy = jest.spyOn(HomeAssistant.prototype, 'connect').mockImplementation(() => {
   console.log(`Mocked connect`);
-  return Promise.resolve();
+  return Promise.resolve('2025.1.0'); // Simulate a successful connection with a version string
 });
 
 const closeSpy = jest.spyOn(HomeAssistant.prototype, 'close').mockImplementation(() => {
@@ -160,7 +160,7 @@ const closeSpy = jest.spyOn(HomeAssistant.prototype, 'close').mockImplementation
 
 const subscribeSpy = jest.spyOn(HomeAssistant.prototype, 'subscribe').mockImplementation(() => {
   console.log(`Mocked subscribe`);
-  return Promise.resolve();
+  return Promise.resolve(1); // Simulate a successful subscription with a subscription ID
 });
 
 const fetchDataSpy = jest.spyOn(HomeAssistant.prototype, 'fetchData').mockImplementation(() => {

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -134,7 +134,7 @@ describe('HassPlatform', () => {
 
   const connectSpy = jest.spyOn(HomeAssistant.prototype, 'connect').mockImplementation(() => {
     console.log(`Mocked connect`);
-    return Promise.resolve();
+    return Promise.resolve('2024.09.1');
   });
 
   const closeSpy = jest.spyOn(HomeAssistant.prototype, 'close').mockImplementation(() => {
@@ -142,9 +142,9 @@ describe('HassPlatform', () => {
     return Promise.resolve();
   });
 
-  const subscribeSpy = jest.spyOn(HomeAssistant.prototype, 'subscribe').mockImplementation(() => {
-    console.log(`Mocked subscribe`);
-    return Promise.resolve();
+  const subscribeSpy = jest.spyOn(HomeAssistant.prototype, 'subscribe').mockImplementation((event?: string) => {
+    console.log(`Mocked subscribe: ${event}`);
+    return Promise.resolve(15);
   });
 
   const fetchDataSpy = jest.spyOn(HomeAssistant.prototype, 'fetchData').mockImplementation(() => {
@@ -543,7 +543,7 @@ describe('HassPlatform', () => {
     await new Promise((resolve) => setTimeout(resolve, 100)); // Allow async event handling to complete
     expect(mockLog.notice).toHaveBeenCalledWith(`Connected to Home Assistant 2024.09.1`);
     expect(mockLog.info).toHaveBeenCalledWith(`Fetched data from Home Assistant successfully`);
-    expect(mockLog.info).toHaveBeenCalledWith(`Subscribed to Home Assistant events successfully`);
+    expect(mockLog.info).toHaveBeenCalledWith(`Subscribed to Home Assistant events successfully with id 15`);
 
     jest.clearAllMocks();
     fetchDataSpy.mockImplementationOnce(() => {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -27,23 +27,20 @@ import path from 'node:path';
 import { promises as fs } from 'node:fs';
 
 // @matter imports
-import { Thermostat, OnOff, ColorControl, BridgedDeviceBasicInformation, SmokeCoAlarm, BooleanState } from 'matterbridge/matter/clusters';
+import { OnOff, BridgedDeviceBasicInformation, SmokeCoAlarm } from 'matterbridge/matter/clusters';
 import { ClusterRegistry } from 'matterbridge/matter/types';
 
 // Matterbridge imports
 import {
   Matterbridge,
   PlatformConfig,
-  MatterbridgeColorControlServer,
   MatterbridgeDynamicPlatform,
   MatterbridgeEndpoint,
-  MatterbridgeThermostatServer,
   bridgedNode,
   colorTemperatureLight,
   extendedColorLight,
   onOffOutlet,
   smokeCoAlarm,
-  MatterbridgeSmokeCoAlarmServer,
   waterLeakDetector,
   waterFreezeDetector,
   contactSensor,
@@ -54,7 +51,7 @@ import { NodeStorage, NodeStorageManager } from 'matterbridge/storage';
 
 // Plugin imports
 import { HassDevice, HassEntity, HassState, HomeAssistant, HassConfig as HassConfig, HomeAssistantPrimitive, HassServices, HassArea } from './homeAssistant.js';
-import { MutableDevice, getClusterServerObj } from './mutableDevice.js';
+import { MutableDevice } from './mutableDevice.js';
 import {
   hassCommandConverter,
   hassDomainAttributeConverter,
@@ -65,7 +62,6 @@ import {
   hassUpdateAttributeConverter,
   hassUpdateStateConverter,
 } from './converters.js';
-import { BooleanStateServer } from 'matterbridge/matter/behaviors';
 
 export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
   // NodeStorageManager
@@ -427,84 +423,31 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
         this.log.info(`Creating endpoint ${CYAN}${entity.entity_id}${nf} for device ${idn}${device.name}${rs}${nf} id ${CYAN}${device.id}${nf}`);
         const child = await mutableDevice.createChildEndpoint(entity.entity_id);
 
+        // For some clusters we need to set the features and to set the default values for the fixed attributes
+        const deviceTypeCodes = mutableDevice.get(entity.entity_id).deviceTypes.map((d) => d.code);
+
         // Special case for binary_sensor domain: configure the contactSensor cluster default values.
-        if (domain === 'binary_sensor' && mutableDevice.get(entity.entity_id).deviceTypes[0].code === contactSensor.code) {
-          mutableDevice.addClusterServerObjs(
-            entity.entity_id,
-            getClusterServerObj(
-              BooleanState.Cluster.id,
-              BooleanStateServer.enable({
-                events: { stateChange: true },
-              }),
-              {
-                stateValue: hassState.state === 'on' ? false : true,
-              },
-            ),
-          );
+        if (domain === 'binary_sensor' && deviceTypeCodes.includes(contactSensor.code)) {
+          this.log.debug(`= contactSensor device ${CYAN}${entity.entity_id}${db} state ${CYAN}${hassState.state}${db}`);
+          mutableDevice.addClusterServerBooleanState(entity.entity_id, hassState.state === 'on' ? false : true);
         }
 
         // Special case for binary_sensor domain: configure the BooleanState cluster default value.
-        if (
-          domain === 'binary_sensor' &&
-          (mutableDevice.get(entity.entity_id).deviceTypes[0].code === waterLeakDetector.code ||
-            mutableDevice.get(entity.entity_id).deviceTypes[0].code === waterFreezeDetector.code)
-        ) {
-          mutableDevice.addClusterServerObjs(
-            entity.entity_id,
-            getClusterServerObj(
-              BooleanState.Cluster.id,
-              BooleanStateServer.enable({
-                events: { stateChange: true },
-              }),
-              {
-                stateValue: hassState.state === 'on' ? true : false,
-              },
-            ),
-          );
+        if (domain === 'binary_sensor' && (deviceTypeCodes.includes(waterLeakDetector.code) || deviceTypeCodes.includes(waterFreezeDetector.code))) {
+          this.log.debug(`= waterLeakDetector/waterFreezeDetector device ${CYAN}${entity.entity_id}${db} state ${CYAN}${hassState.state}${db}`);
+          mutableDevice.addClusterServerBooleanState(entity.entity_id, hassState.state === 'on' ? true : false);
         }
 
         // Special case for binary_sensor domain: configure the SmokeCoAlarm cluster default values with feature SmokeAlarm.
         if (domain === 'binary_sensor' && mutableDevice.get(entity.entity_id).deviceTypes[0].code === smokeCoAlarm.code) {
-          mutableDevice.addClusterServerObjs(
-            entity.entity_id,
-            getClusterServerObj(
-              SmokeCoAlarm.Cluster.id,
-              MatterbridgeSmokeCoAlarmServer.with(SmokeCoAlarm.Feature.SmokeAlarm).enable({
-                events: {
-                  smokeAlarm: true,
-                  interconnectSmokeAlarm: false,
-                  coAlarm: false,
-                  interconnectCoAlarm: false,
-                  lowBattery: true,
-                  hardwareFault: true,
-                  endOfService: true,
-                  selfTestComplete: true,
-                  alarmMuted: true,
-                  muteEnded: true,
-                  allClear: true,
-                },
-              }),
-              {
-                smokeState: hassState.state === 'on' ? SmokeCoAlarm.ExpressedState.SmokeAlarm : SmokeCoAlarm.ExpressedState.Normal,
-                expressedState: SmokeCoAlarm.ExpressedState.Normal,
-                batteryAlert: SmokeCoAlarm.AlarmState.Normal,
-                deviceMuted: SmokeCoAlarm.MuteState.NotMuted,
-                testInProgress: false,
-                hardwareFaultAlert: false,
-                endOfServiceAlert: SmokeCoAlarm.EndOfService.Normal,
-              },
-            ),
-          );
+          this.log.debug(`= smokeCoAlarm device ${CYAN}${entity.entity_id}${db} state ${CYAN}${hassState.state}${db}`);
+          mutableDevice.addClusterServerSmokeCoAlarm(entity.entity_id, hassState.state === 'on' ? SmokeCoAlarm.ExpressedState.SmokeAlarm : SmokeCoAlarm.ExpressedState.Normal);
         }
 
         // Special case for light domain: configure the ColorControl cluster default values. Real values will be updated by the configure with the Home Assistant states. Here we need the fixed attributes to be set.
-        if (
-          domain === 'light' &&
-          (mutableDevice.get(entity.entity_id).deviceTypes[0].code === colorTemperatureLight.code ||
-            mutableDevice.get(entity.entity_id).deviceTypes[0].code === extendedColorLight.code)
-        ) {
+        if (domain === 'light' && (deviceTypeCodes.includes(colorTemperatureLight.code) || deviceTypeCodes.includes(extendedColorLight.code))) {
           this.log.debug(
-            `= colorControl supported_color_modes: ${CYAN}${hassState.attributes['supported_color_modes']}${db} min_mireds: ${CYAN}${hassState.attributes['min_mireds']}${db} max_mireds: ${CYAN}${hassState.attributes['max_mireds']}${db}`,
+            `= colorControl device ${CYAN}${entity.entity_id}${db} supported_color_modes: ${CYAN}${hassState.attributes['supported_color_modes']}${db} min_mireds: ${CYAN}${hassState.attributes['min_mireds']}${db} max_mireds: ${CYAN}${hassState.attributes['max_mireds']}${db}`,
           );
           if (
             isValidArray(hassState.attributes['supported_color_modes']) &&
@@ -515,50 +458,18 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
             !hassState.attributes['supported_color_modes'].includes('rgbww') &&
             hassState.attributes['supported_color_modes'].includes('color_temp')
           ) {
-            mutableDevice.addClusterServerObjs(
+            mutableDevice.addClusterServerColorTemperatureColorControl(
               entity.entity_id,
-              getClusterServerObj(ColorControl.Cluster.id, MatterbridgeColorControlServer.with(ColorControl.Feature.ColorTemperature), {
-                colorMode: ColorControl.ColorMode.ColorTemperatureMireds,
-                enhancedColorMode: ColorControl.EnhancedColorMode.ColorTemperatureMireds,
-                colorCapabilities: { xy: false, hueSaturation: false, colorLoop: false, enhancedHue: false, colorTemperature: true },
-                options: {
-                  executeIfOff: false,
-                },
-                numberOfPrimaries: null,
-                colorTemperatureMireds: (hassState.attributes['max_mireds'] as number | undefined) ?? 250,
-                colorTempPhysicalMinMireds: (hassState.attributes['min_mireds'] as number | undefined) ?? 147,
-                colorTempPhysicalMaxMireds: (hassState.attributes['max_mireds'] as number | undefined) ?? 500,
-                coupleColorTempToLevelMinMireds: (hassState.attributes['min_mireds'] as number | undefined) ?? 147,
-                remainingTime: 0,
-                startUpColorTemperatureMireds: null,
-              }),
+              hassState.attributes['color_temp'] ?? 250,
+              hassState.attributes['min_mireds'] ?? 147,
+              hassState.attributes['max_mireds'] ?? 500,
             );
           } else {
-            mutableDevice.addClusterServerObjs(
+            mutableDevice.addClusterServerColorControl(
               entity.entity_id,
-              getClusterServerObj(
-                ColorControl.Cluster.id,
-                MatterbridgeColorControlServer.with(ColorControl.Feature.ColorTemperature, ColorControl.Feature.HueSaturation, ColorControl.Feature.Xy),
-                {
-                  colorMode: ColorControl.ColorMode.CurrentHueAndCurrentSaturation,
-                  enhancedColorMode: ColorControl.EnhancedColorMode.CurrentHueAndCurrentSaturation,
-                  colorCapabilities: { xy: true, hueSaturation: true, colorLoop: false, enhancedHue: false, colorTemperature: true },
-                  options: {
-                    executeIfOff: false,
-                  },
-                  numberOfPrimaries: null,
-                  currentX: 0,
-                  currentY: 0,
-                  currentHue: 0,
-                  currentSaturation: 0,
-                  colorTemperatureMireds: (hassState.attributes['color_temp'] as number | undefined) ?? 250,
-                  colorTempPhysicalMinMireds: (hassState.attributes['min_mireds'] as number | undefined) ?? 147,
-                  colorTempPhysicalMaxMireds: (hassState.attributes['max_mireds'] as number | undefined) ?? 500,
-                  coupleColorTempToLevelMinMireds: (hassState.attributes['min_mireds'] as number | undefined) ?? 147,
-                  remainingTime: 0,
-                  startUpColorTemperatureMireds: null,
-                },
-              ),
+              hassState.attributes['color_temp'] ?? 250,
+              hassState.attributes['min_mireds'] ?? 147,
+              hassState.attributes['max_mireds'] ?? 500,
             );
           }
         }
@@ -566,66 +477,40 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
         // Special case for climate domain: configure the Thermostat cluster default values and features. Real values will be updated by the configure with the Home Assistant states. Here we need the fixed attributes to be set.
         if (domain === 'climate') {
           if (isValidArray(hassState?.attributes['hvac_modes']) && hassState.attributes['hvac_modes'].includes('heat_cool')) {
-            mutableDevice.addClusterServerObjs(
+            this.log.debug(`= thermostat device ${CYAN}${entity.entity_id}${db} state ${CYAN}${hassState.attributes['hvac_modes']}${db}`);
+            mutableDevice.addClusterServerAutoModeThermostat(
               entity.entity_id,
-              getClusterServerObj(Thermostat.Cluster.id, MatterbridgeThermostatServer.with(Thermostat.Feature.AutoMode, Thermostat.Feature.Heating, Thermostat.Feature.Cooling), {
-                localTemperature: ((hassState.attributes['current_temperature'] as number | undefined) ?? 23) * 100,
-                systemMode: Thermostat.SystemMode.Auto,
-                controlSequenceOfOperation: Thermostat.ControlSequenceOfOperation.CoolingAndHeating,
-                // Thermostat.Feature.Heating
-                occupiedHeatingSetpoint: ((hassState.attributes['target_temp_low'] as number | undefined) ?? 21) * 100,
-                minHeatSetpointLimit: ((hassState.attributes['min_temp'] as number | undefined) ?? 0) * 100,
-                absMinHeatSetpointLimit: ((hassState.attributes['min_temp'] as number | undefined) ?? 0) * 100,
-                maxHeatSetpointLimit: ((hassState.attributes['max_temp'] as number | undefined) ?? 50) * 100,
-                absMaxHeatSetpointLimit: ((hassState.attributes['max_temp'] as number | undefined) ?? 50) * 100,
-                // Thermostat.Feature.Cooling
-                occupiedCoolingSetpoint: ((hassState.attributes['target_temp_high'] as number | undefined) ?? 25) * 100,
-                minCoolSetpointLimit: ((hassState.attributes['min_temp'] as number | undefined) ?? 0) * 100,
-                absMinCoolSetpointLimit: ((hassState.attributes['min_temp'] as number | undefined) ?? 0) * 100,
-                maxCoolSetpointLimit: ((hassState.attributes['max_temp'] as number | undefined) ?? 50) * 100,
-                absMaxCoolSetpointLimit: ((hassState.attributes['max_temp'] as number | undefined) ?? 50) * 100,
-                // Thermostat.Feature.AutoMode
-                minSetpointDeadBand: 1 * 100,
-                thermostatRunningMode: Thermostat.ThermostatRunningMode.Off,
-              }),
+              hassState.attributes['current_temperature'] ?? 23,
+              hassState.attributes['target_temp_low'] ?? 21,
+              hassState.attributes['target_temp_high'] ?? 25,
+              hassState.attributes['min_temp'] ?? 0,
+              hassState.attributes['max_temp'] ?? 50,
             );
           } else if (
             isValidArray(hassState?.attributes['hvac_modes']) &&
             hassState.attributes['hvac_modes'].includes('heat') &&
             !hassState.attributes['hvac_modes'].includes('cool')
           ) {
-            mutableDevice.addClusterServerObjs(
+            this.log.debug(`= thermostat device ${CYAN}${entity.entity_id}${db} state ${CYAN}${hassState.attributes['hvac_modes']}${db}`);
+            mutableDevice.addClusterServerHeatingThermostat(
               entity.entity_id,
-              getClusterServerObj(Thermostat.Cluster.id, MatterbridgeThermostatServer.with(Thermostat.Feature.Heating), {
-                localTemperature: ((hassState.attributes['current_temperature'] as number | undefined) ?? 23) * 100,
-                systemMode: Thermostat.SystemMode.Heat,
-                controlSequenceOfOperation: Thermostat.ControlSequenceOfOperation.HeatingOnly,
-                // Thermostat.Feature.Heating
-                occupiedHeatingSetpoint: ((hassState.attributes['temperature'] as number | undefined) ?? 21) * 100,
-                minHeatSetpointLimit: ((hassState.attributes['min_temp'] as number | undefined) ?? 0) * 100,
-                absMinHeatSetpointLimit: ((hassState.attributes['min_temp'] as number | undefined) ?? 0) * 100,
-                maxHeatSetpointLimit: ((hassState.attributes['max_temp'] as number | undefined) ?? 50) * 100,
-                absMaxHeatSetpointLimit: ((hassState.attributes['max_temp'] as number | undefined) ?? 50) * 100,
-              }),
+              hassState.attributes['current_temperature'] ?? 23,
+              hassState.attributes['temperature'] ?? 21,
+              hassState.attributes['min_temp'] ?? 0,
+              hassState.attributes['max_temp'] ?? 50,
             );
           } else if (
             isValidArray(hassState?.attributes['hvac_modes']) &&
             hassState.attributes['hvac_modes'].includes('cool') &&
             !hassState.attributes['hvac_modes'].includes('heat')
           ) {
-            mutableDevice.addClusterServerObjs(
+            this.log.debug(`= thermostat device ${CYAN}${entity.entity_id}${db} state ${CYAN}${hassState.attributes['hvac_modes']}${db}`);
+            mutableDevice.addClusterServerCoolingThermostat(
               entity.entity_id,
-              getClusterServerObj(Thermostat.Cluster.id, MatterbridgeThermostatServer.with(Thermostat.Feature.Cooling), {
-                localTemperature: ((hassState.attributes['current_temperature'] as number | undefined) ?? 23) * 100,
-                systemMode: Thermostat.SystemMode.Cool,
-                controlSequenceOfOperation: Thermostat.ControlSequenceOfOperation.CoolingOnly,
-                // Thermostat.Feature.Cooling
-                occupiedCoolingSetpoint: ((hassState.attributes['temperature'] as number | undefined) ?? 25) * 100,
-                minCoolSetpointLimit: ((hassState.attributes['min_temp'] as number | undefined) ?? 0) * 100,
-                absMinCoolSetpointLimit: ((hassState.attributes['min_temp'] as number | undefined) ?? 0) * 100,
-                maxCoolSetpointLimit: ((hassState.attributes['max_temp'] as number | undefined) ?? 50) * 100,
-                absMaxCoolSetpointLimit: ((hassState.attributes['max_temp'] as number | undefined) ?? 50) * 100,
-              }),
+              hassState.attributes['current_temperature'] ?? 23,
+              hassState.attributes['temperature'] ?? 21,
+              hassState.attributes['min_temp'] ?? 0,
+              hassState.attributes['max_temp'] ?? 50,
             );
           }
         }
@@ -651,7 +536,6 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
             const check = child.hasAttributeServer(hassSubscribe.clusterId, hassSubscribe.attribute);
             this.log.debug(`- subscribe: ${CYAN}${ClusterRegistry.get(hassSubscribe.clusterId)?.name}${db}:${CYAN}${hassSubscribe.attribute}${db} check ${CYAN}${check}${db}`);
             if (!check) continue;
-
             child.subscribeAttribute(
               hassSubscribe.clusterId,
               hassSubscribe.attribute,
@@ -893,6 +777,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
         // console.error('Processing update attributes: ', hassUpdateAttributes.length);
         for (const update of hassUpdateAttributes) {
           // console.error('- processing update attribute', update.with, 'value', new_state.attributes[update.with]);
+          // @ts-expect-error: dynamic property access for Home Assistant state attribute
           const value = new_state.attributes[update.with];
           if (value !== null) {
             const convertedValue = update.converter(value, new_state);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -98,7 +98,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
 
     this.config.namePostfix = isValidString(this.config.namePostfix, 1, 3) ? this.config.namePostfix : '';
     this.config.postfix = isValidString(this.config.postfix, 1, 3) ? this.config.postfix : '';
-    this.config.reconnectTimeout = isValidNumber(config.reconnectTimeout, 0) ? config.reconnectTimeout : undefined;
+    this.config.reconnectTimeout = isValidNumber(config.reconnectTimeout, 30) ? config.reconnectTimeout : undefined;
     this.config.reconnectRetries = isValidNumber(config.reconnectRetries, 0) ? config.reconnectRetries : undefined;
     this.config.certificatePath = isValidString(config.certificatePath, 1) ? config.certificatePath : undefined;
     this.config.rejectUnauthorized = isValidBoolean(config.rejectUnauthorized) ? config.rejectUnauthorized : undefined;
@@ -127,8 +127,8 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
 
       this.log.info(`Subscribing to Home Assistant events...`);
       try {
-        await this.ha.subscribe();
-        this.log.info(`Subscribed to Home Assistant events successfully`);
+        const subscriptionId = await this.ha.subscribe();
+        this.log.info(`Subscribed to Home Assistant events successfully with id ${subscriptionId}`);
       } catch (error) {
         this.log.error(`Error subscribing to Home Assistant events: ${error}`);
       }


### PR DESCRIPTION
## Breaking changes

Since release 0.1.0:

- the config parameters individualEntityWhiteList and individualEntityBlackList have been removed. Use the normal white and black lists.
- the config serialPostfix has been changed to postfix.

## [0.1.2] - 2025-06-07

### Added

- [homeassistant]: Typed HassWebSocketResponses and HassWebSocketRequests.
- [homeassistant]: Added subscribe() and Jest test.
- [homeassistant]: Added unsubscribe() and Jest test.
- [binary_sensor]: Added domain binary_sensor with deviceClass 'garage_door'. It creates a contactSensor with BooleanState cluster.
- [binary_sensor]: Added domain binary_sensor with deviceClass 'window'. It creates a contactSensor with BooleanState cluster.
- [jest]: Added real Jest test to test the HomeAssistant api with a real Home Assistant setup.

### Changed

- [config]: Enhanced reconnect config description and set minimum value to 30 secs for reconnectTimeout.

### Fixed

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="bmc-button.svg" alt="Buy me a coffee" width="80">
</a>