### PR TITLE
Release 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 [![Docker Version](https://img.shields.io/docker/v/luligu/matterbridge?label=docker%20version&sort=semver)](https://hub.docker.com/r/luligu/matterbridge)
 [![Docker Pulls](https://img.shields.io/docker/pulls/luligu/matterbridge.svg)](https://hub.docker.com/r/luligu/matterbridge)
 ![Node.js CI](https://github.com/Luligu/matterbridge-hass/actions/workflows/build-matterbridge-plugin.yml/badge.svg)
-![Coverage](https://img.shields.io/badge/Jest%20coverage-100%25-brightgreen)
+![CodeQL](https://github.com/Luligu/matterbridge-hass/actions/workflows/codeql.yml/badge.svg)
+[![codecov](https://codecov.io/gh/Luligu/matterbridge-hass/branch/main/graph/badge.svg)](https://codecov.io/gh/Luligu/matterbridge-hass)
 
 [![power by](https://img.shields.io/badge/powered%20by-matterbridge-blue)](https://www.npmjs.com/package/matterbridge)
 [![power by](https://img.shields.io/badge/powered%20by-node--ansi--logger-blue)](https://www.npmjs.com/package/node-ansi-logger)

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -71,6 +71,9 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
   /** Home Assistant instance */
   ha: HomeAssistant;
 
+  /** Home Assistant subscription ID */
+  haSubscriptionId: number | null = null;
+
   /** Convert the label filter in the config from name to label_id */
   labelIdFilter: string = '';
 
@@ -132,8 +135,8 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
 
       this.log.info(`Subscribing to Home Assistant events...`);
       try {
-        const subscriptionId = await this.ha.subscribe();
-        this.log.info(`Subscribed to Home Assistant events successfully with id ${subscriptionId}`);
+        this.haSubscriptionId = await this.ha.subscribe();
+        this.log.info(`Subscribed to Home Assistant events successfully with id ${this.haSubscriptionId}`);
       } catch (error) {
         this.log.error(`Error subscribing to Home Assistant events: ${error}`);
       }
@@ -215,7 +218,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       this.log.error(`Error connecting to Home Assistant: ${error}`);
     }
     const check = () => {
-      return this.ha.connected && this.ha.hassConfig !== null && this.ha.hassServices !== null;
+      return this.ha.connected && this.ha.hassConfig !== null && this.ha.hassServices !== null && this.haSubscriptionId !== null;
     };
     await waiter('Home Assistant connected', check, true, 30000, 1000); // Wait for 30 seconds with 1 second interval and throw error if not connected
 


### PR DESCRIPTION
## [0.1.4] - 2025-06-28

### Added

- [homeassistant]: Added HassLabel.
- [homeassistant]: Added core_config_updated message handler to fetch the new config.
- [homeassistant]: Add queue for fetching updates.
- [config]: Added applyFiltersToDeviceEntities option to schema.
- [config]: Improved filtering logic for label. Now is possible to use the label id or the label name in the label filter.
- [DevContainer]: Added support for the [**Matterbridge Plugin Dev Container**](https://github.com/Luligu/matterbridge/blob/dev/README-DEV.md#matterbridge-plugin-dev-container) with optimized named volumes for `matterbridge` and `node_modules`.
- [GitHub]: Added GitHub issue templates for bug reports and feature requests.
- [ESLint]: Refactored the flat config.
- [ESLint]: Added the plugins `eslint-plugin-promise`, `eslint-plugin-jsdoc`, and `@vitest/eslint-plugin`.
- [Jest]: Refactored the flat config.
- [Vitest]: Added Vitest for TypeScript project testing. It will replace Jest, which does not work correctly with ESM module mocks.
- [JSDoc]: Added missing JSDoc comments, including `@param` and `@returns` tags.
- [CodeQL]: Added CodeQL badge in the readme.
- [Codecov]: Added Codecov badge in the readme.

### Changed

- [package]: Updated package to Automator v. 2.0.1.
- [package]: Update dependencies.
- [storage]: Bumped `node-storage-manager` to 2.0.0.
- [logger]: Bumped `node-ansi-logger` to 3.1.1.
- [package]: Requires matterbridge 3.1.0.
- [worflows]: Removed workflows running on node 18 since it reached the end-of-life in April 2025.

### Fixed

- [state]: Fix state update when both old and new state are unavailable.

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="bmc-button.svg" alt="Buy me a coffee" width="80">
</a>