### PR TITLE
Standalone entities support

### DIFF
--- a/mock/homeassistant.json
+++ b/mock/homeassistant.json
@@ -926,6 +926,91 @@
     {
       "area_id": null,
       "categories": {},
+      "config_entry_id": "01JXFQ3R5EPZRY5DWWF153PZEN",
+      "config_subentry_id": null,
+      "created_at": 1749652753.11215,
+      "device_id": null,
+      "disabled_by": null,
+      "entity_category": null,
+      "entity_id": "climate.ac_bedroom",
+      "has_entity_name": false,
+      "hidden_by": null,
+      "icon": "m3of:ac-unit",
+      "id": "23a475804e8d919383cfc178f686186c",
+      "labels": ["ac"],
+      "modified_at": 1753208297.871264,
+      "name": "Bedroom mini-split",
+      "options": {
+        "conversation": {
+          "should_expose": true
+        }
+      },
+      "original_name": "Bedroom AC",
+      "platform": "gree",
+      "translation_key": "gree",
+      "unique_id": "climate.gree_c03937a87611"
+    },
+    {
+      "area_id": null,
+      "categories": {},
+      "config_entry_id": "01JXFQB6T7MGHPY99YZRE44Z63",
+      "config_subentry_id": null,
+      "created_at": 1749653232.465044,
+      "device_id": null,
+      "disabled_by": null,
+      "entity_category": null,
+      "entity_id": "climate.ac_living_room",
+      "has_entity_name": false,
+      "hidden_by": null,
+      "icon": "m3of:ac-unit",
+      "id": "0fd9c45c6d1c5645aaee8f39e7d79321",
+      "labels": ["ac"],
+      "modified_at": 1753208310.564766,
+      "name": "Living Room mini-split",
+      "options": {
+        "conversation": {
+          "should_expose": true
+        }
+      },
+      "original_name": "Living room AC",
+      "platform": "gree",
+      "translation_key": "gree",
+      "unique_id": "climate.gree_c03937a50ac3"
+    },
+    {
+      "area_id": null,
+      "categories": {},
+      "config_entry_id": "01JSTV5GTC9HE2EFTESFFS25V8",
+      "config_subentry_id": null,
+      "created_at": 1745731371.85309,
+      "device_id": null,
+      "disabled_by": null,
+      "entity_category": null,
+      "entity_id": "sensor.temperature_in_living_room",
+      "has_entity_name": false,
+      "hidden_by": null,
+      "icon": "mdi:temperature-celsius",
+      "id": "f2f939336e89a4ed9adc4844ade8579e",
+      "labels": [],
+      "modified_at": 1754826859.992127,
+      "name": null,
+      "options": {
+        "conversation": {
+          "should_expose": true
+        },
+        "sensor": {
+          "display_precision": 1,
+          "suggested_display_precision": 1
+        }
+      },
+      "original_name": "temperature in living room",
+      "platform": "group",
+      "translation_key": null,
+      "unique_id": "01JSTV5GTC9HE2EFTESFFS25V8"
+    },
+    {
+      "area_id": null,
+      "categories": {},
       "config_entry_id": "01J6J7D7EADB8KNX8XBDYDNB1B",
       "created_at": 1737993627.221181,
       "device_id": "dc0b13b9f9d848b90201f926ab7a5c96",

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -795,7 +795,8 @@ describe('HassPlatform', () => {
     const tempDevice = haPlatform.matterbridgeDevices.get('sensor.temperature_in_living_room');
     const livingChild = livingDevice?.getChildEndpointByName('climate.ac_living_room') || livingDevice?.getChildEndpointByName('climate.ac_living_room'.replaceAll('.', ''));
     const bedroomChild = bedroomDevice?.getChildEndpointByName('climate.ac_bedroom') || bedroomDevice?.getChildEndpointByName('climate.ac_bedroom'.replaceAll('.', ''));
-  const tempChild = tempDevice?.getChildEndpointByName('sensor.temperature_in_living_room') || tempDevice?.getChildEndpointByName('sensor.temperature_in_living_room'.replaceAll('.', ''));
+    const tempChild =
+      tempDevice?.getChildEndpointByName('sensor.temperature_in_living_room') || tempDevice?.getChildEndpointByName('sensor.temperature_in_living_room'.replaceAll('.', ''));
     expect(livingChild).toBeDefined();
     expect(bedroomChild).toBeDefined();
     expect(tempChild).toBeDefined();

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -408,8 +408,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
         hassDomains.forEach((hassDomain) => {
           if (hassDomain.deviceType) mutableDevice.addDeviceTypes(endpointName, hassDomain.deviceType);
           if (hassDomain.clusterId) mutableDevice.addClusterServerIds(endpointName, hassDomain.clusterId);
-          if (hassDomain.deviceType && isValidString(hassState.attributes['friendly_name']))
-            mutableDevice.setFriendlyName(endpointName, hassState.attributes['friendly_name']);
+          if (hassDomain.deviceType && isValidString(hassState.attributes['friendly_name'])) mutableDevice.setFriendlyName(endpointName, hassState.attributes['friendly_name']);
         });
       }
 
@@ -541,7 +540,11 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
             hassState.attributes['min_temp'] ?? 0,
             hassState.attributes['max_temp'] ?? 50,
           );
-        } else if (isValidArray(hassState?.attributes['hvac_modes']) && hassState.attributes['hvac_modes'].includes('heat') && !hassState.attributes['hvac_modes'].includes('cool')) {
+        } else if (
+          isValidArray(hassState?.attributes['hvac_modes']) &&
+          hassState.attributes['hvac_modes'].includes('heat') &&
+          !hassState.attributes['hvac_modes'].includes('cool')
+        ) {
           this.log.debug(`= thermostat device ${CYAN}${entity.entity_id}${db} state ${CYAN}${hassState.attributes['hvac_modes']}${db}`);
           mutableDevice.addClusterServerHeatingThermostat(
             endpointName,
@@ -550,7 +553,11 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
             hassState.attributes['min_temp'] ?? 0,
             hassState.attributes['max_temp'] ?? 50,
           );
-        } else if (isValidArray(hassState?.attributes['hvac_modes']) && hassState.attributes['hvac_modes'].includes('cool') && !hassState.attributes['hvac_modes'].includes('heat')) {
+        } else if (
+          isValidArray(hassState?.attributes['hvac_modes']) &&
+          hassState.attributes['hvac_modes'].includes('cool') &&
+          !hassState.attributes['hvac_modes'].includes('heat')
+        ) {
           this.log.debug(`= thermostat device ${CYAN}${entity.entity_id}${db} state ${CYAN}${hassState.attributes['hvac_modes']}${db}`);
           mutableDevice.addClusterServerCoolingThermostat(
             endpointName,


### PR DESCRIPTION
I've just figured instead of nagging you to do thinks or raise issues I'd better help you out. I hope the code is good and as for testing - I had no problems with it, especially awesome dev experience with containers and everything, kudos to you @Luligu 

### Summary
This PR adds support for Home Assistant entities that are not bound to a device (device_id === null). Such standalone entities are now discovered and exposed as individual Matterbridge devices when supported by the domain converters, with proper endpoints, clusters, command/subscribe handlers, and special cases aligned with the existing device flow.

### What’s changed

**Standalone entities discovery:**
New scan step that processes entities with device_id === null.
Respects whitelist/blacklist and area/label filters via setSelectDevice, setSelectEntity, validateDevice, isValidAreaLabel.
Skips domains already handled (automation, scene, script, input_boolean, input_button) and template switch.

**Domain mapping and enrichment:**
Base mapping via hassDomainConverter (deviceType, clusterId, friendly name).
Attribute-based enrichment via hassDomainAttributeConverter (e.g., light color/brightness).
Sensors via hassDomainSensorsConverter (matches state_class + device_class, optional endpoint selection).
Binary sensors via hassDomainBinarySensorsConverter (matches device_class, optional endpoint selection).
AirQuality special-case via regex.

**Device creation:**
Builds a MutableDevice per entity with bridged node, composed type “Hass Entity”, configUrl, and endpointName keyed by entity_id (stored in endpointNames).

**Special cases (parity with device flow):**
PowerSource (battery) → PowerSource cluster with charge level.
Binary sensors: contact/leak/freeze → BooleanState mapping.
Smoke/CO → SmokeCoAlarm (AlarmState).
Lights: ColorControl vs ColorTemperature depending on supported_color_modes and mireds.
Climate:
heat_cool → AutoModeThermostat (current temp + low/high + min/max).
heat only → HeatingThermostat.
cool only → CoolingThermostat.

**Handlers:**
addCommandHandler and addSubscribeHandler wired per-domain using converters.

**Registration and lookups:**
mutableDevice.create() + registerDevice; devices keyed in matterbridgeDevices by entity_id.
subscribeHandler now falls back to lookup by entity_id when device_id is absent.

**Logging:**
More informative message when an entity has no state (includes disabled_by when available).

**Files touched:**
platform.ts — new standalone entities flow; subscribeHandler fallback; minor log tweak.
platform.test.ts — new test for standalone entities; adjusted expected device counts due to extra registrations.
homeassistant.json — added three standalone entities used by tests.

**Tests added/updated**
should register standalone climate and temperature sensor entities
Sets up only three standalone entities and corresponding states.
Verifies registration under matterbridgeDevices keyed by entity_id.
Confirms child endpoints exist with names derived from entity_id.
After onConfigure, asserts setAttributeSpy calls for:
Climate (heat_cool): systemMode, occupiedHeatingSetpoint, occupiedCoolingSetpoint, localTemperature.
Climate (cool only): occupiedCoolingSetpoint, localTemperature.
Sensor (temperature): measuredValue.