### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ See also the breaking changes of the releases 0.4.0 and 0.3.0 please.
 - [select]: Added select to splitEntities. It is possibile to pick up from the list of entities.
 - [readme]: Improved the readme.
 - [jest]: Added an helper to make all tests standard and more efficient.
+- [platform]: Typed HomeAssistantPlatformConfig.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ For the naming issues (expecially upsetting with Alexa) read the explanation and
 
 ## [0.4.1] - 2025-09-??
 
+### Breaking changes
+
+See also releases 0.4.0 and 0.3.0 please.
+
 ### Added
 
 - [battery]: Added support for battery type individual and split entities (battery low, battery level and battery voltage).
@@ -49,7 +53,7 @@ For the naming issues (expecially upsetting with Alexa) read the explanation and
 
 Since in Matter there is no official way to change an existing endpoint (only Matter 1.4.2 introduces it),
 
-**if the controller have issues to show the new device composition, try to power it off, wait 5 minutes, then power it again.**
+**if the controller has issues to show the new device composition, try to power it off, wait 5 minutes, then power it again.**
 
 On the Matterbridge log you should see after a while this line.
 
@@ -59,9 +63,7 @@ When you see this message in the log, you can power again the controller (or may
 
 **If this still doesn't solve the issue, you may need to reset all the registered devices (from the frontend) or repair the bridge.**
 
-With the release 0.3.0 and after, all supported domains are available also in the individual entities. This will bring in a lot of new Matter devices. I suggest to check carefully the whiteList and the blackList and also the log for duplicated names.
-
-The vacuum domain have been added. When pairing to Apple Home always enable enableServerRvc in the config (default to true).
+See also release 0.3.0 please.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ If you like this project and find it useful, please consider giving it a star on
 - add fan cluster to climate domain or use AirConditioner for climate (Tamer). On hold cause Google Home cannot show correctly the AirConditioner device type.
 - add fan preset_mode converter for "Normal" and "Auto" and not standard preset_modes.
 - add water heater domain (requested by Ludovic BOUÉ).
+- add media_player domain (requested by Tamer).
 
 ### Naming issues explained
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ For the naming issues (expecially upsetting with Alexa) read the explanation and
 
 ### Breaking changes
 
-See also releases 0.4.0 and 0.3.0 please.
+See also the breaking changes of the releases 0.4.0 and 0.3.0 please.
 
 ### Added
 
@@ -59,11 +59,11 @@ On the Matterbridge log you should see after a while this line.
 
 [22:35:38.583] [ServerSubscription] Sending update failed 3 times in a row, canceling subscription 3926576955 and let controller subscribe again.
 
-When you see this message in the log, you can power again the controller (or maybe just wait 5 minutes).
+When you see this message in the log, you can power again the controller (or maybe just wait the 5 minutes).
 
 **If this still doesn't solve the issue, you may need to reset all the registered devices (from the frontend) or repair the bridge.**
 
-See also release 0.3.0 please.
+See also the breaking changes of the release 0.3.0 please.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ If you like this project and find it useful, please consider giving it a star on
 
 For the naming issues (expecially upsetting with Alexa) read the explanation and the solution [here](https://github.com/Luligu/matterbridge-hass/discussions/86).
 
+## [0.4.1] - 2025-09-??
+
+### Added
+
+### Changed
+
+- [package]: Updated dependencies.
+
+<a href="https://www.buymeacoffee.com/luligugithub">
+  <img src="bmc-button.svg" alt="Buy me a coffee" width="80">
+</a>
+
 ## [0.4.0] - 2025-09-02
 
 ### Breaking changes
@@ -65,6 +77,10 @@ The vacuum domain have been added. When pairing to Apple Home always enable enab
 ### Fixed
 
 - [vacuum]: Fix bug causing the plugin not to load when the vaccum is a device entitiy and has no battery and enableServerRvc is enabled (https://github.com/Luligu/matterbridge-hass/issues/88).
+
+<a href="https://www.buymeacoffee.com/luligugithub">
+  <img src="bmc-button.svg" alt="Buy me a coffee" width="80">
+</a>
 
 ## [0.3.0] - 2025-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 For the naming issues (expecially upsetting with Alexa) read the explanation and the solution [here](https://github.com/Luligu/matterbridge-hass/discussions/86).
 
-## [0.4.1] - 2025-09-??
+## [0.4.1] - 2025-09-06
 
 ### Breaking changes
 
@@ -37,6 +37,8 @@ See also the breaking changes of the releases 0.4.0 and 0.3.0 please.
 
 - [battery]: Added support for battery type individual and split entities (battery low, battery level and battery voltage).
 - [select]: Added select to splitEntities. It is possibile to pick up from the list of entities.
+- [readme]: Improved the readme.
+- [jest]: Added an helper to make all tests standard and more efficient.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ See also the breaking changes of the releases 0.4.0 and 0.3.0 please.
 ### Added
 
 - [battery]: Added support for battery type individual and split entities (battery low, battery level and battery voltage).
+- [select]: Added select to splitEntities. It is possibile to pick up from the list of entities.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ For the naming issues (expecially upsetting with Alexa) read the explanation and
 
 ### Added
 
+- [battery]: Added support for battery type individual and split entities (battery low, battery level and battery voltage).
+
 ### Changed
 
 - [package]: Updated dependencies.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Features:
 - It is possible to select from a list the individual entities to include in the white or black list. Select by name, id or entity_id.
 - It is possible to select from a list the devices to include in the white or black list. Select by name or id.
 - It is possible to select from a list the entities to include in the device entity black list.
+- It is possible to pickup from a list the split entities.
 - It is possible to postfix the Matter device serialNumber and the Matter device name to avoid collision with other instances.
 
 ## Supported device entities:
@@ -46,7 +47,7 @@ Features:
 (1) - Supported preset_modes: auto, low, medium, high.
 (2) - The Apple Home crashes if the Rvc is inside the bridge. If you pair with Apple Home use the server mode in the config.
 
-These domains are supported also like individual entities.
+These domains are supported also like individual and split entities.
 
 ## Supported individual entities:
 
@@ -184,6 +185,8 @@ You find these special entities in Home Assistant at http://localhost:8123/confi
 
 All the individual entities use the main whiteList, blackList.
 
+Since the release 0.4.0 it is also possible to pickup any device entity and split ("decompose") it to make it an independent Matter device.
+
 ## Config
 
 You may need to set some config values in the frontend (wait that the plugin has been configured before changing the config):
@@ -218,23 +221,23 @@ Number of times to try to reconnect before giving up.
 
 ### filterByArea
 
-Filter devices and individual entities by area. If enabled, only devices and individual entities in the selected areas will be exposed. If disabled, all devices and individual entities will be exposed. This doesn't filter entities that belong to a device unless applyFiltersToDeviceEntities is set.
+Filter devices and individual entities by area. If enabled, only devices and individual entities in the selected areas will be exposed. If disabled, all devices and individual entities will be exposed. This doesn't filter entities that belong to a device unless applyFiltersToDeviceEntities is set (in this case also the device needs to belong to this area).
 
 ### filterByLabel
 
-Filter devices and individual entities by label. If enabled, only devices and individual entities with the selected labels will be exposed. If disabled, all devices and individual entities will be exposed. This doesn't filter entities that belong to a device unless applyFiltersToDeviceEntities is set.
+Filter devices and individual entities by label. If enabled, only devices and individual entities with the selected labels will be exposed. If disabled, all devices and individual entities will be exposed. This doesn't filter entities that belong to a device unless applyFiltersToDeviceEntities is set is set (in this case also the device must have this label).
 
 ### applyFiltersToDeviceEntities
 
-Apply the filters also to device entities. If enabled, the filters will be applied to device entities as well. If disabled, the filters will only be applied to devices and individual entities.
+Apply the filters also to device entities. If enabled, the filters will be applied to device entities as well (also the device needs to have the area and label). If disabled, the filters will only be applied to devices and individual entities.
 
 ### whiteList
 
-If the whiteList is defined only the devices and the individual entities included are exposed to Matter. Use the device/entity name or the device/entity id.
+If the whiteList is defined only the devices and the individual and split entities included are exposed to Matter. Use the device/entity name or the device/entity id.
 
 ### blackList
 
-If the blackList is defined the devices and the individual entities included will not be exposed to Matter. Use the device/entity name or the device/entity id.
+If the blackList is defined the devices and the individual and split entities included will not be exposed to Matter. Use the device/entity name or the device/entity id.
 
 ### deviceEntityBlackList
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,8 @@ Without further setup, the controller will show 2 switch with the same name (dif
 
 Solution:
 
-- add switch.computer_plug_child_lock to splitEntities.
+- add switch.computer_plug_child_lock (use entity_id) to splitEntities and restart.
+- if you use the whiteList, select your switch.computer_plug_child_lock (will show up with the entity name "Computer plug Child lock") and restart.
 
 In this way, the controller will show one switch with name "Computer plug" and a second with name "Computer plug Child lock".
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Suppose we have a device named "Computer plug" with 3 entities:
 - id switch.computer_plug_child_lock named "Computer plug Child lock" that is the child lock for the plug
 - id temperature.computer_plug named "Computer plug Device temperature" that is the device temperature (very used in the zigbee world)
 
-Without further setup, the controller will show 2 switch with the same name (difficult to distinguish them). Alexa will show 3 devices "Computer plug", "First outlet" and "Second outlet".
+Without further setup, the controller will show 2 switch with the same name (difficult to distinguish them). Alexa will show 3 devices "Computer plug", "First plug" and "Second plug".
 
 Solution:
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,8 +12,8 @@ const jestConfig = {
   ...presetConfig,
   testEnvironment: 'node',
   moduleNameMapper: { '^(\\.{1,2}/.*)\\.js$': '$1' }, // Handle ESM imports by removing the .js extension
-  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/vitest/'],
-  coveragePathIgnorePatterns: ['/node_modules/', '/dist/', '/vitest/'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/vitest/', 'jestHelpers.ts'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/dist/', '/vitest/', 'jestHelpers.ts'],
   maxWorkers: '100%',
 };
 

--- a/matterbridge-hass.schema.json
+++ b/matterbridge-hass.schema.json
@@ -84,7 +84,7 @@
         "type": "string"
       },
       "uniqueItems": true,
-      "selectEntityFrom": "name",
+      "selectEntityFrom": "description",
       "ui:widget": "hidden"
     },
     "deviceEntityBlackList": {
@@ -108,7 +108,8 @@
       "items": {
         "type": "string"
       },
-      "uniqueItems": true
+      "uniqueItems": true,
+      "selectEntityFrom": "description"
     },
     "namePostfix": {
       "description": "Add this unique postfix (3 characters max) to each device name to avoid collision with other instances (you may loose the configuration of the devices in your controller when changing this value or you may need to pair again the controller).",

--- a/matterbridge-hass.schema.json
+++ b/matterbridge-hass.schema.json
@@ -103,7 +103,7 @@
       }
     },
     "splitEntities": {
-      "description": "The device entities in the list will be exposed like an independent device and removed from their device.",
+      "description": "The device entities in the list will be exposed like an independent device and removed from their device. Enter the entity_id (i.e. switch.computer_plug_child_lock).",
       "type": "array",
       "items": {
         "type": "string"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge-hass",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-hass",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "node-ansi-logger": "3.1.1",
@@ -20,11 +20,11 @@
         "@types/node": "24.3.0",
         "@types/ws": "8.18.1",
         "@vitest/coverage-v8": "3.2.4",
-        "@vitest/eslint-plugin": "1.3.5",
+        "@vitest/eslint-plugin": "1.3.6",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-jest": "29.0.1",
-        "eslint-plugin-jsdoc": "54.1.1",
+        "eslint-plugin-jsdoc": "54.2.1",
         "eslint-plugin-n": "17.21.3",
         "eslint-plugin-prettier": "5.5.4",
         "eslint-plugin-promise": "7.2.1",
@@ -34,7 +34,7 @@
         "shx": "0.4.0",
         "ts-jest": "29.4.1",
         "typescript": "5.9.2",
-        "typescript-eslint": "8.41.0",
+        "typescript-eslint": "8.42.0",
         "vitest": "3.2.4"
       },
       "engines": {
@@ -2439,17 +2439,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.41.0.tgz",
-      "integrity": "sha512-8fz6oa6wEKZrhXWro/S3n2eRJqlRcIa6SlDh59FXJ5Wp5XRZ8B9ixpJDcjadHq47hMx0u+HW6SNa6LjJQ6NLtw==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.42.0.tgz",
+      "integrity": "sha512-Aq2dPqsQkxHOLfb2OPv43RnIvfj05nw8v/6n3B2NABIPpHnjQnaLo9QGMTvml+tv4korl/Cjfrb/BYhoL8UUTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.41.0",
-        "@typescript-eslint/type-utils": "8.41.0",
-        "@typescript-eslint/utils": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0",
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/type-utils": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -2463,7 +2463,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.41.0",
+        "@typescript-eslint/parser": "^8.42.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -2479,16 +2479,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.41.0.tgz",
-      "integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.42.0.tgz",
+      "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.41.0",
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0",
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2504,14 +2504,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.41.0.tgz",
-      "integrity": "sha512-b8V9SdGBQzQdjJ/IO3eDifGpDBJfvrNTp2QD9P2BeqWTGrRibgfgIlBSw6z3b6R7dPzg752tOs4u/7yCLxksSQ==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.42.0.tgz",
+      "integrity": "sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.41.0",
-        "@typescript-eslint/types": "^8.41.0",
+        "@typescript-eslint/tsconfig-utils": "^8.42.0",
+        "@typescript-eslint/types": "^8.42.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2526,14 +2526,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.41.0.tgz",
-      "integrity": "sha512-n6m05bXn/Cd6DZDGyrpXrELCPVaTnLdPToyhBoFkLIMznRUQUEQdSp96s/pcWSQdqOhrgR1mzJ+yItK7T+WPMQ==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.42.0.tgz",
+      "integrity": "sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0"
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2544,9 +2544,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.41.0.tgz",
-      "integrity": "sha512-TDhxYFPUYRFxFhuU5hTIJk+auzM/wKvWgoNYOPcOf6i4ReYlOoYN8q1dV5kOTjNQNJgzWN3TUUQMtlLOcUgdUw==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.42.0.tgz",
+      "integrity": "sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2561,15 +2561,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.41.0.tgz",
-      "integrity": "sha512-63qt1h91vg3KsjVVonFJWjgSK7pZHSQFKH6uwqxAH9bBrsyRhO6ONoKyXxyVBzG1lJnFAJcKAcxLS54N1ee1OQ==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.42.0.tgz",
+      "integrity": "sha512-9KChw92sbPTYVFw3JLRH1ockhyR3zqqn9lQXol3/YbI6jVxzWoGcT3AsAW0mu1MY0gYtsXnUGV/AKpkAj5tVlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0",
-        "@typescript-eslint/utils": "8.41.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -2586,9 +2586,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.41.0.tgz",
-      "integrity": "sha512-9EwxsWdVqh42afLbHP90n2VdHaWU/oWgbH2P0CfcNfdKL7CuKpwMQGjwev56vWu9cSKU7FWSu6r9zck6CVfnag==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.42.0.tgz",
+      "integrity": "sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2600,16 +2600,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.41.0.tgz",
-      "integrity": "sha512-D43UwUYJmGhuwHfY7MtNKRZMmfd8+p/eNSfFe6tH5mbVDto+VQCayeAt35rOx3Cs6wxD16DQtIKw/YXxt5E0UQ==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.42.0.tgz",
+      "integrity": "sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.41.0",
-        "@typescript-eslint/tsconfig-utils": "8.41.0",
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0",
+        "@typescript-eslint/project-service": "8.42.0",
+        "@typescript-eslint/tsconfig-utils": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2629,16 +2629,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.41.0.tgz",
-      "integrity": "sha512-udbCVstxZ5jiPIXrdH+BZWnPatjlYwJuJkDA4Tbo3WyYLh8NvB+h/bKeSZHDOFKfphsZYJQqaFtLeXEqurQn1A==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.42.0.tgz",
+      "integrity": "sha512-JnIzu7H3RH5BrKC4NoZqRfmjqCIS1u3hGZltDYJgkVdqAezl4L9d1ZLw+36huCujtSBSAirGINF/S4UxOcR+/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.41.0",
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0"
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2653,13 +2653,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.41.0.tgz",
-      "integrity": "sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.42.0.tgz",
+      "integrity": "sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.41.0",
+        "@typescript-eslint/types": "8.42.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -2994,9 +2994,9 @@
       }
     },
     "node_modules/@vitest/eslint-plugin": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.3.5.tgz",
-      "integrity": "sha512-vdQL1s+Yb9i7xXFur0qRpECwkafrp+L84EXppg3Xs+Iu+5M8smkh5I2rD5opD7cEaSBE3UEebB3xbDANqALpKA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.3.6.tgz",
+      "integrity": "sha512-sa/QAljHbUP+sMdPjK8e/6nS2+QB/bh1aDKEkAKMqsKVzBXqz4LRYfT7UVGIP8LMIrskGTxqAbHuiL+FOYWzHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4202,9 +4202,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.211",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.211.tgz",
-      "integrity": "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==",
+      "version": "1.5.212",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.212.tgz",
+      "integrity": "sha512-gE7ErIzSW+d8jALWMcOIgf+IB6lpfsg6NwOhPVwKzDtN2qcBix47vlin4yzSregYDxTCXOUqAZjVY/Z3naS7ww==",
       "dev": true,
       "license": "ISC"
     },
@@ -4754,9 +4754,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "54.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-54.1.1.tgz",
-      "integrity": "sha512-qoY2Gl0OkvATXIxRaG2irS2ue78+RTaOyYrADvg1ue+9FHE+2Mp7RcpO0epkuhhQgOkH/REv1oJFe58dYv8SGg==",
+      "version": "54.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-54.2.1.tgz",
+      "integrity": "sha512-RHmDsuxbMXJ11HVHuJJ4nlWxN+LKykDaL2evNuODshslR4sRPJPiiGwih8lNpwyFwSe9Apc6zMMXHWq/7P2mPA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -9492,16 +9492,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.41.0.tgz",
-      "integrity": "sha512-n66rzs5OBXW3SFSnZHr2T685q1i4ODm2nulFJhMZBotaTavsS8TrI3d7bDlRSs9yWo7HmyWrN9qDu14Qv7Y0Dw==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.42.0.tgz",
+      "integrity": "sha512-ozR/rQn+aQXQxh1YgbCzQWDFrsi9mcg+1PM3l/z5o1+20P7suOIaNg515bpr/OYt6FObz/NHcBstydDLHWeEKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.41.0",
-        "@typescript-eslint/parser": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0",
-        "@typescript-eslint/utils": "8.41.0"
+        "@typescript-eslint/eslint-plugin": "8.42.0",
+        "@typescript-eslint/parser": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-hass",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Matterbridge hass plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",
@@ -111,11 +111,11 @@
     "@types/node": "24.3.0",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "3.2.4",
-    "@vitest/eslint-plugin": "1.3.5",
+    "@vitest/eslint-plugin": "1.3.6",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jest": "29.0.1",
-    "eslint-plugin-jsdoc": "54.1.1",
+    "eslint-plugin-jsdoc": "54.2.1",
     "eslint-plugin-n": "17.21.3",
     "eslint-plugin-prettier": "5.5.4",
     "eslint-plugin-promise": "7.2.1",
@@ -125,7 +125,7 @@
     "shx": "0.4.0",
     "ts-jest": "29.4.1",
     "typescript": "5.9.2",
-    "typescript-eslint": "8.41.0",
+    "typescript-eslint": "8.42.0",
     "vitest": "3.2.4"
   }
 }

--- a/src/homeAssistant.real.test.ts
+++ b/src/homeAssistant.real.test.ts
@@ -1,62 +1,22 @@
 // src\homeAssistant.real.test.ts
 
+const MATTER_PORT = 0;
+const NAME = 'HomeAssistantReal';
+const HOMEDIR = path.join('jest', NAME);
+
 // Home Assistant Real WebSocket Client Tests on a local host
 
 import fs from 'node:fs';
 import path from 'node:path';
 
 import { jest } from '@jest/globals';
-import { AnsiLogger, LogLevel } from 'matterbridge/logger';
+import { LogLevel } from 'matterbridge/logger';
 
 import { HassArea, HassConfig, HassDevice, HassEntity, HassServices, HassState, HomeAssistant } from './homeAssistant.js';
+import { loggerLogSpy, setupTest } from './jestHelpers.js';
 
-let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
-let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
-let consoleDebugSpy: jest.SpiedFunction<typeof console.log>;
-let consoleInfoSpy: jest.SpiedFunction<typeof console.log>;
-let consoleWarnSpy: jest.SpiedFunction<typeof console.log>;
-let consoleErrorSpy: jest.SpiedFunction<typeof console.log>;
-const debug = false; // Set to true to enable debug logging
-
-if (!debug) {
-  loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
-  consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {});
-  consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation((...args: any[]) => {});
-  consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation((...args: any[]) => {});
-  consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: any[]) => {});
-  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {});
-} else {
-  loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
-  consoleLogSpy = jest.spyOn(console, 'log');
-  consoleDebugSpy = jest.spyOn(console, 'debug');
-  consoleInfoSpy = jest.spyOn(console, 'info');
-  consoleWarnSpy = jest.spyOn(console, 'warn');
-  consoleErrorSpy = jest.spyOn(console, 'error');
-}
-
-function setDebug(debug: boolean) {
-  if (debug) {
-    loggerLogSpy.mockRestore();
-    consoleLogSpy.mockRestore();
-    consoleDebugSpy.mockRestore();
-    consoleInfoSpy.mockRestore();
-    consoleWarnSpy.mockRestore();
-    consoleErrorSpy.mockRestore();
-    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
-    consoleLogSpy = jest.spyOn(console, 'log');
-    consoleDebugSpy = jest.spyOn(console, 'debug');
-    consoleInfoSpy = jest.spyOn(console, 'info');
-    consoleWarnSpy = jest.spyOn(console, 'warn');
-    consoleErrorSpy = jest.spyOn(console, 'error');
-  } else {
-    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
-    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {});
-    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation((...args: any[]) => {});
-    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation((...args: any[]) => {});
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: any[]) => {});
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {});
-  }
-}
+// Setup the test environment
+setupTest(NAME, false);
 
 let accessToken: string | null = null;
 try {

--- a/src/homeAssistant.test.ts
+++ b/src/homeAssistant.test.ts
@@ -1,5 +1,9 @@
 // src\homeAssistant.test.ts
 
+const MATTER_PORT = 0;
+const NAME = 'HomeAssistant';
+const HOMEDIR = path.join('jest', NAME);
+
 // Home Assistant WebSocket Client Tests
 
 /* eslint-disable jest/no-conditional-expect */
@@ -15,54 +19,10 @@ import { AnsiLogger, CYAN, db, er, LogLevel } from 'matterbridge/logger';
 import { wait } from 'matterbridge/utils';
 
 import { HassArea, HassConfig, HassDevice, HassEntity, HassLabel, HassServices, HassState, HassWebSocketResponseResult, HomeAssistant } from './homeAssistant.js';
+import { loggerLogSpy, setupTest } from './jestHelpers.js';
 
-let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
-let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
-let consoleDebugSpy: jest.SpiedFunction<typeof console.log>;
-let consoleInfoSpy: jest.SpiedFunction<typeof console.log>;
-let consoleWarnSpy: jest.SpiedFunction<typeof console.log>;
-let consoleErrorSpy: jest.SpiedFunction<typeof console.log>;
-const debug = false; // Set to true to enable debug logging
-
-if (!debug) {
-  loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
-  consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {});
-  consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation((...args: any[]) => {});
-  consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation((...args: any[]) => {});
-  consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: any[]) => {});
-  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {});
-} else {
-  loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
-  consoleLogSpy = jest.spyOn(console, 'log');
-  consoleDebugSpy = jest.spyOn(console, 'debug');
-  consoleInfoSpy = jest.spyOn(console, 'info');
-  consoleWarnSpy = jest.spyOn(console, 'warn');
-  consoleErrorSpy = jest.spyOn(console, 'error');
-}
-
-function setDebug(debug: boolean) {
-  if (debug) {
-    loggerLogSpy.mockRestore();
-    consoleLogSpy.mockRestore();
-    consoleDebugSpy.mockRestore();
-    consoleInfoSpy.mockRestore();
-    consoleWarnSpy.mockRestore();
-    consoleErrorSpy.mockRestore();
-    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
-    consoleLogSpy = jest.spyOn(console, 'log');
-    consoleDebugSpy = jest.spyOn(console, 'debug');
-    consoleInfoSpy = jest.spyOn(console, 'info');
-    consoleWarnSpy = jest.spyOn(console, 'warn');
-    consoleErrorSpy = jest.spyOn(console, 'error');
-  } else {
-    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
-    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {});
-    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation((...args: any[]) => {});
-    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation((...args: any[]) => {});
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: any[]) => {});
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {});
-  }
-}
+// Setup the test environment
+setupTest(NAME, false);
 
 describe('HomeAssistant', () => {
   let server: WebSocketServer;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,63 +8,16 @@ import path from 'node:path';
 import { rmSync } from 'node:fs';
 
 import { jest } from '@jest/globals';
-import { Matterbridge, MatterbridgeEndpoint, PlatformConfig } from 'matterbridge';
-import { AnsiLogger } from 'matterbridge/logger';
+import { type Matterbridge, MatterbridgeEndpoint, PlatformConfig } from 'matterbridge';
+import { AnsiLogger, CYAN, nf, rs, LogLevel, idn, TimestampFormat } from 'matterbridge/logger';
 
-import { HomeAssistantPlatform } from './platform.js';
+import { HomeAssistantPlatform, HomeAssistantPlatformConfig } from './platform.js';
+import { consoleDebugSpy, consoleErrorSpy, consoleInfoSpy, consoleLogSpy, consoleWarnSpy, loggerLogSpy, setDebug, setupTest } from './jestHelpers.js';
 
 import initializePlugin from './index.js';
 
-let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
-let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
-let consoleDebugSpy: jest.SpiedFunction<typeof console.log>;
-let consoleInfoSpy: jest.SpiedFunction<typeof console.log>;
-let consoleWarnSpy: jest.SpiedFunction<typeof console.log>;
-let consoleErrorSpy: jest.SpiedFunction<typeof console.log>;
-const debug = false; // Set to true to enable debug logging
-
-if (!debug) {
-  loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
-  consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {});
-  consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation((...args: any[]) => {});
-  consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation((...args: any[]) => {});
-  consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: any[]) => {});
-  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {});
-} else {
-  loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
-  consoleLogSpy = jest.spyOn(console, 'log');
-  consoleDebugSpy = jest.spyOn(console, 'debug');
-  consoleInfoSpy = jest.spyOn(console, 'info');
-  consoleWarnSpy = jest.spyOn(console, 'warn');
-  consoleErrorSpy = jest.spyOn(console, 'error');
-}
-
-function setDebug(debug: boolean) {
-  if (debug) {
-    loggerLogSpy.mockRestore();
-    consoleLogSpy.mockRestore();
-    consoleDebugSpy.mockRestore();
-    consoleInfoSpy.mockRestore();
-    consoleWarnSpy.mockRestore();
-    consoleErrorSpy.mockRestore();
-    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
-    consoleLogSpy = jest.spyOn(console, 'log');
-    consoleDebugSpy = jest.spyOn(console, 'debug');
-    consoleInfoSpy = jest.spyOn(console, 'info');
-    consoleWarnSpy = jest.spyOn(console, 'warn');
-    consoleErrorSpy = jest.spyOn(console, 'error');
-  } else {
-    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
-    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {});
-    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation((...args: any[]) => {});
-    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation((...args: any[]) => {});
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: any[]) => {});
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {});
-  }
-}
-
-// Cleanup the test environment
-rmSync(HOMEDIR, { recursive: true, force: true });
+// Setup the test environment
+setupTest(NAME, false);
 
 describe('initializePlugin', () => {
   beforeEach(() => {
@@ -75,14 +28,7 @@ describe('initializePlugin', () => {
     jest.restoreAllMocks();
   });
 
-  const mockLog = {
-    fatal: jest.fn((message: string, ...parameters: any[]) => {}),
-    error: jest.fn((message: string, ...parameters: any[]) => {}),
-    warn: jest.fn((message: string, ...parameters: any[]) => {}),
-    notice: jest.fn((message: string, ...parameters: any[]) => {}),
-    info: jest.fn((message: string, ...parameters: any[]) => {}),
-    debug: jest.fn((message: string, ...parameters: any[]) => {}),
-  } as unknown as AnsiLogger;
+  const log = new AnsiLogger({ logName: NAME, logTimestampFormat: TimestampFormat.TIME_MILLIS, logLevel: LogLevel.DEBUG });
 
   const mockMatterbridge = {
     matterbridgeDirectory: HOMEDIR + '/.matterbridge',
@@ -94,7 +40,7 @@ describe('initializePlugin', () => {
       nodeVersion: '22.1.10',
     },
     matterbridgeVersion: '3.2.4',
-    log: mockLog,
+    log,
     getDevices: jest.fn(() => []),
     getPlugins: jest.fn(() => []),
     addBridgedEndpoint: jest.fn(async (pluginName: string, device: MatterbridgeEndpoint) => {}),
@@ -105,26 +51,42 @@ describe('initializePlugin', () => {
   const mockConfig = {
     name: 'matterbridge-hass',
     type: 'DynamicPlatform',
-    host: 'http://homeassistant.local:8123',
+    version: '1.0.0',
+    host: 'ws://homeassistant.local:8123',
     token: 'long-lived token',
-    certificatePath: undefined,
+    certificatePath: '',
     rejectUnauthorized: true,
     reconnectTimeout: 60,
     reconnectRetries: 10,
     filterByArea: '',
     filterByLabel: '',
+    applyFiltersToDeviceEntities: false,
     whiteList: [],
     blackList: [],
     entityBlackList: [],
     deviceEntityBlackList: {},
+    splitEntities: [],
+    namePostfix: '',
+    postfix: '',
+    airQualityRegex: '',
     enableServerRvc: false,
     debug: false,
     unregisterOnShutdown: false,
-  } as PlatformConfig;
+  } as HomeAssistantPlatformConfig;
+
+  let platform: HomeAssistantPlatform;
 
   it('should return an instance of HomeAssistantPlatform', async () => {
-    const platform = initializePlugin(mockMatterbridge, mockLog, mockConfig);
+    platform = initializePlugin(mockMatterbridge, log, mockConfig);
     expect(platform).toBeInstanceOf(HomeAssistantPlatform);
-    await platform.onShutdown();
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Initializing platform: ${CYAN}${mockConfig.name}${nf} version: ${CYAN}${mockConfig.version}${rs}`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Initialized platform: ${CYAN}${mockConfig.name}${nf} version: ${CYAN}${mockConfig.version}${rs}`);
+  });
+
+  it('should shutdown the platform', async () => {
+    expect(platform).toBeInstanceOf(HomeAssistantPlatform);
+    await platform.onShutdown('Unit test shutdown');
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Shutting down platform ${idn}${mockConfig.name}${rs}${nf}: Unit test shutdown`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Shut down platform ${idn}${mockConfig.name}${rs}${nf} completed`);
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -126,6 +126,5 @@ describe('initializePlugin', () => {
     const platform = initializePlugin(mockMatterbridge, mockLog, mockConfig);
     expect(platform).toBeInstanceOf(HomeAssistantPlatform);
     await platform.onShutdown();
-    // await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for ha.close() to complete
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,10 +20,10 @@
  * limitations under the License.
  */
 
-import { Matterbridge, PlatformConfig } from 'matterbridge';
+import { Matterbridge } from 'matterbridge';
 import { AnsiLogger } from 'matterbridge/logger';
 
-import { HomeAssistantPlatform } from './platform.js';
+import { HomeAssistantPlatform, HomeAssistantPlatformConfig } from './platform.js';
 
 /**
  * This is the standard interface for Matterbridge plugins.
@@ -31,9 +31,10 @@ import { HomeAssistantPlatform } from './platform.js';
  *
  * @param {Matterbridge} matterbridge - An instance of MatterBridge. This is the main interface for interacting with the MatterBridge system.
  * @param {AnsiLogger} log - An instance of AnsiLogger. This is used for logging messages in a format that can be displayed with ANSI color codes.
- * @param {PlatformConfig} config - The platform configuration.
+ * @param {HomeAssistantPlatformConfig} config - The HomeAssistantPlatform platform configuration.
+ *
  * @returns {HomeAssistantPlatform} - An instance of the HomeAssistantPlatform. This is the main interface for interacting with Home Assistant.
  */
-export default function initializePlugin(matterbridge: Matterbridge, log: AnsiLogger, config: PlatformConfig): HomeAssistantPlatform {
+export default function initializePlugin(matterbridge: Matterbridge, log: AnsiLogger, config: HomeAssistantPlatformConfig): HomeAssistantPlatform {
   return new HomeAssistantPlatform(matterbridge, log, config);
 }

--- a/src/jestHelpers.ts
+++ b/src/jestHelpers.ts
@@ -1,9 +1,9 @@
 /**
  * @description This file contains the Jest helpers.
- * @file src/jest/helpers.test.ts
+ * @file src/helpers.test.ts
  * @author Luca Liguori
  * @created 2025-09-03
- * @version 1.0.2
+ * @version 1.0.3
  * @license Apache-2.0
  *
  * Copyright 2025, 2026, 2027 Luca Liguori.
@@ -23,15 +23,18 @@
 
 import { rmSync } from 'node:fs';
 import { inspect } from 'node:util';
+import path from 'node:path';
 
 // Imports from Matterbridge
 /*
+import { jest } from '@jest/globals';
 import { DeviceTypeId, Endpoint, Environment, ServerNode, ServerNodeStore, VendorId, LogFormat as MatterLogFormat, LogLevel as MatterLogLevel, Lifecycle } from '@matter/main';
 import { AggregatorEndpoint, RootEndpoint } from '@matter/main/endpoints';
 import { MdnsService } from '@matter/main/protocol';
 */
 
 // Imports from a plugin
+import { jest } from '@jest/globals';
 import {
   DeviceTypeId,
   Endpoint,
@@ -45,6 +48,111 @@ import {
   Lifecycle,
 } from 'matterbridge/matter';
 import { RootEndpoint, AggregatorEndpoint } from 'matterbridge/matter/endpoints';
+import { AnsiLogger } from 'matterbridge/logger';
+
+export let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
+export let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+export let consoleDebugSpy: jest.SpiedFunction<typeof console.log>;
+export let consoleInfoSpy: jest.SpiedFunction<typeof console.log>;
+export let consoleWarnSpy: jest.SpiedFunction<typeof console.log>;
+export let consoleErrorSpy: jest.SpiedFunction<typeof console.log>;
+
+/**
+ * Setup the Jest environment:
+ * - it will remove any existing home directory.
+ * - setup the spies for logging.
+ 
+ * @param {string} name The name of the test suite.
+ * @param {boolean} debug If true, the logging is not mocked.
+ *
+ * ```typescript
+ * import { consoleDebugSpy, consoleErrorSpy, consoleInfoSpy, consoleLogSpy, consoleWarnSpy, loggerLogSpy, setDebug, setupTest } from './jestHelpers.js';
+ *
+ * // Setup the test environment
+ * setupTest(true);
+ *
+ * // Cleanup the test environment
+ * rmSync(HOMEDIR, { recursive: true, force: true });
+ * ```
+ */
+export function setupTest(name: string, debug: boolean = false): void {
+  expect(name).toBeDefined();
+  expect(typeof name).toBe('string');
+  expect(name.length).toBeGreaterThanOrEqual(4); // avoid accidental deletion of short paths like "/" or "C:\"
+
+  // Cleanup any existing home directory
+  rmSync(path.join('jest', name), { recursive: true, force: true });
+
+  if (debug) {
+    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
+    consoleLogSpy = jest.spyOn(console, 'log');
+    consoleDebugSpy = jest.spyOn(console, 'debug');
+    consoleInfoSpy = jest.spyOn(console, 'info');
+    consoleWarnSpy = jest.spyOn(console, 'warn');
+    consoleErrorSpy = jest.spyOn(console, 'error');
+  } else {
+    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation(() => {});
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  }
+}
+
+/**
+ * Set or unset the debug mode.
+ *
+ * @param {boolean} debug If true, the logging is not mocked.
+ */
+export function setDebug(debug: boolean): void {
+  if (debug) {
+    loggerLogSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleDebugSpy.mockRestore();
+    consoleInfoSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
+    consoleLogSpy = jest.spyOn(console, 'log');
+    consoleDebugSpy = jest.spyOn(console, 'debug');
+    consoleInfoSpy = jest.spyOn(console, 'info');
+    consoleWarnSpy = jest.spyOn(console, 'warn');
+    consoleErrorSpy = jest.spyOn(console, 'error');
+  } else {
+    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation(() => {});
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  }
+}
+
+/**
+ * Create a Matterbridge Environment for testing.
+ * It will remove any existing home directory.
+ *
+ * @param {string} homeDir Home directory for the environment.
+ * @returns {Environment}  The created environment.
+ */
+export function createTestEnvironment(homeDir: string): Environment {
+  expect(homeDir).toBeDefined();
+  expect(typeof homeDir).toBe('string');
+  expect(homeDir.length).toBeGreaterThanOrEqual(4); // avoid accidental deletion of short paths like "/" or "C:\"
+
+  // Cleanup any existing home directory
+  rmSync(homeDir, { recursive: true, force: true });
+
+  // Setup the matter environment
+  const environment = Environment.default;
+  environment.vars.set('log.level', MatterLogLevel.DEBUG);
+  environment.vars.set('log.format', MatterLogFormat.ANSI);
+  environment.vars.set('path.root', homeDir);
+  environment.vars.set('runtime.signals', false);
+  environment.vars.set('runtime.exitcode', false);
+  return environment;
+}
 
 /**
  * Advance the Node.js event loop deterministically to allow chained asynchronous work (Promises scheduled in
@@ -130,31 +238,6 @@ export async function assertAllEndpointNumbersPersisted(targetServer: ServerNode
     }
   }
   return all.length;
-}
-
-/**
- * Create a Matterbridge Environment for testing.
- * It will remove any existing home directory.
- *
- * @param {string} homeDir Home directory for the environment.
- * @returns {Environment}  The created environment.
- */
-export function createTestEnvironment(homeDir: string): Environment {
-  expect(homeDir).toBeDefined();
-  expect(typeof homeDir).toBe('string');
-  expect(homeDir.length).toBeGreaterThan(5); // avoid accidental deletion of short paths like "/" or "C:\"
-
-  // Cleanup any existing home directory
-  rmSync(homeDir, { recursive: true, force: true });
-
-  // Setup the matter environment
-  const environment = Environment.default;
-  environment.vars.set('log.level', MatterLogLevel.DEBUG);
-  environment.vars.set('log.format', MatterLogFormat.ANSI);
-  environment.vars.set('path.root', homeDir);
-  environment.vars.set('runtime.signals', false);
-  environment.vars.set('runtime.exitcode', false);
-  return environment;
 }
 
 /**

--- a/src/jestHelpers.ts
+++ b/src/jestHelpers.ts
@@ -1,0 +1,329 @@
+/**
+ * @description This file contains the Jest helpers.
+ * @file src/jest/helpers.test.ts
+ * @author Luca Liguori
+ * @created 2025-09-03
+ * @version 1.0.2
+ * @license Apache-2.0
+ *
+ * Copyright 2025, 2026, 2027 Luca Liguori.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { rmSync } from 'node:fs';
+import { inspect } from 'node:util';
+
+// Imports from Matterbridge
+/*
+import { DeviceTypeId, Endpoint, Environment, ServerNode, ServerNodeStore, VendorId, LogFormat as MatterLogFormat, LogLevel as MatterLogLevel, Lifecycle } from '@matter/main';
+import { AggregatorEndpoint, RootEndpoint } from '@matter/main/endpoints';
+import { MdnsService } from '@matter/main/protocol';
+*/
+
+// Imports from a plugin
+import {
+  DeviceTypeId,
+  Endpoint,
+  Environment,
+  MdnsService,
+  ServerNode,
+  ServerNodeStore,
+  VendorId,
+  LogFormat as MatterLogFormat,
+  LogLevel as MatterLogLevel,
+  Lifecycle,
+} from 'matterbridge/matter';
+import { RootEndpoint, AggregatorEndpoint } from 'matterbridge/matter/endpoints';
+
+/**
+ * Advance the Node.js event loop deterministically to allow chained asynchronous work (Promises scheduled in
+ * microtasks and follow‑up macrotasks) to complete inside tests without adding arbitrary long timeouts.
+ *
+ * NOTE: This does not guarantee OS level network IO completion—only JavaScript task queue progression inside the
+ *       current process.
+ *
+ * @param {number} ticks       Number of macrotask (setImmediate) turns to yield (default 3).
+ * @param {number} microTurns  Number of microtask drains (Promise.resolve chains) after macrotask yielding (default 10).
+ * @param {number} pause       Final timer delay in ms; set 0 to disable (default 100ms).
+ * @returns {Promise<void>}        Resolves after the requested event loop advancement has completed.
+ */
+export async function flushAsync(ticks: number = 3, microTurns: number = 10, pause: number = 100): Promise<void> {
+  for (let i = 0; i < ticks; i++) await new Promise((resolve) => setImmediate(resolve));
+  for (let i = 0; i < microTurns; i++) await Promise.resolve();
+  if (pause) await new Promise((resolve) => setTimeout(resolve, pause));
+}
+
+/**
+ * Flush (await) the lazy endpoint number persistence mechanism used by matter.js.
+ *
+ * Background:
+ *  assignNumber() batches persistence (store.saveNumber + updating __nextNumber__) via an internal promise (#numbersPersisted).
+ *  Calling endpointStores.close() waits for the current batch only. If new endpoints were added in the same macrotask
+ *  cycle additional micro/macro turns might be needed to ensure the batch started. We defensively yield macrotasks
+ *  (setImmediate) and then await close() multiple rounds.
+ *
+ * @param {ServerNode} targetServer  The server whose endpoint numbering persistence should be flushed.
+ * @param {number} rounds Number of macrotask + close cycles to run (2 is usually sufficient; 1 often works).
+ * @returns {Promise<void>}          Resolves when pending number persistence batches have completed.
+ */
+export async function flushAllEndpointNumberPersistence(targetServer: ServerNode, rounds: number = 2): Promise<void> {
+  const nodeStore = targetServer.env.get(ServerNodeStore);
+  for (let i = 0; i < rounds; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+    await nodeStore.endpointStores.close();
+  }
+}
+
+/**
+ * Collect all endpoints in the server endpoint tree (root -> descendants).
+ *
+ * @param {Endpoint} root  Root endpoint (typically the ServerNode root endpoint cast as Endpoint).
+ * @returns {Endpoint[]}   Flat array including the root and every descendant once.
+ */
+function collectAllEndpoints(root: Endpoint): Endpoint[] {
+  const list: Endpoint[] = [];
+  const walk = (ep: Endpoint) => {
+    list.push(ep);
+    if (ep.parts) {
+      for (const child of ep.parts as unknown as Endpoint[]) {
+        walk(child);
+      }
+    }
+  };
+  walk(root);
+  return list;
+}
+
+/**
+ * Assert that every endpoint attached to the server has an assigned and (batch-)persisted endpoint number.
+ *
+ * This waits for any outstanding number persistence batch (endpointStores.close()), then traverses the endpoint
+ * graph and asserts:
+ *  - Root endpoint: number is 0 (allowing undefined to coerce to 0 via nullish coalescing check).
+ *  - All other endpoints: number > 0.
+ *
+ * @param {ServerNode} targetServer The server whose endpoint numbers are verified.
+ * @returns {Promise<void>}         Resolves when assertions complete.
+ */
+export async function assertAllEndpointNumbersPersisted(targetServer: ServerNode): Promise<number> {
+  const nodeStore = targetServer.env.get(ServerNodeStore);
+  // Ensure any pending persistence finished (flush any in-flight batch promise)
+  await nodeStore.endpointStores.close();
+  const all = collectAllEndpoints(targetServer as unknown as Endpoint);
+  for (const ep of all) {
+    const store = nodeStore.storeForEndpoint(ep);
+    if (ep.maybeNumber === 0) {
+      expect(store.number ?? 0).toBe(0); // root
+    } else {
+      expect(store.number).toBeGreaterThan(0);
+    }
+  }
+  return all.length;
+}
+
+/**
+ * Create a Matterbridge Environment for testing.
+ * It will remove any existing home directory.
+ *
+ * @param {string} homeDir Home directory for the environment.
+ * @returns {Environment}  The created environment.
+ */
+export function createTestEnvironment(homeDir: string): Environment {
+  expect(homeDir).toBeDefined();
+  expect(typeof homeDir).toBe('string');
+  expect(homeDir.length).toBeGreaterThan(5); // avoid accidental deletion of short paths like "/" or "C:\"
+
+  // Cleanup any existing home directory
+  rmSync(homeDir, { recursive: true, force: true });
+
+  // Setup the matter environment
+  const environment = Environment.default;
+  environment.vars.set('log.level', MatterLogLevel.DEBUG);
+  environment.vars.set('log.format', MatterLogFormat.ANSI);
+  environment.vars.set('path.root', homeDir);
+  environment.vars.set('runtime.signals', false);
+  environment.vars.set('runtime.exitcode', false);
+  return environment;
+}
+
+/**
+ * Start a Matterbridge ServerNode for testing.
+ *
+ * @param {string} name Name of the server (used for logging and product description).
+ * @param {number} port TCP port to listen on.
+ * @returns {Promise<[ServerNode<ServerNode.RootEndpoint>, Endpoint<AggregatorEndpoint>]>} Resolves to an array containing the created ServerNode and its AggregatorNode.
+ */
+export async function startServerNode(name: string, port: number): Promise<[ServerNode<ServerNode.RootEndpoint>, Endpoint<AggregatorEndpoint>]> {
+  // Create the server node
+  const server = await ServerNode.create({
+    id: name + 'ServerNode',
+
+    productDescription: {
+      name: name + 'ServerNode',
+      deviceType: DeviceTypeId(RootEndpoint.deviceType),
+      vendorId: VendorId(0xfff1),
+      productId: 0x8000,
+    },
+
+    // Provide defaults for the BasicInformation cluster on the Root endpoint
+    basicInformation: {
+      vendorId: VendorId(0xfff1),
+      vendorName: 'Matterbridge',
+      productId: 0x8000,
+      productName: 'Matterbridge ' + name,
+      nodeLabel: name + 'ServerNode',
+      hardwareVersion: 1,
+      softwareVersion: 1,
+      reachable: true,
+    },
+
+    network: {
+      port,
+    },
+  });
+  expect(server).toBeDefined();
+  expect(server.lifecycle.isReady).toBeTruthy();
+
+  // Create the aggregator node
+  const aggregator = new Endpoint(AggregatorEndpoint, {
+    id: name + 'AggregatorNode',
+  });
+  expect(aggregator).toBeDefined();
+
+  // Add the aggregator to the server
+  await server.add(aggregator);
+  expect(server.parts.has(aggregator.id)).toBeTruthy();
+  expect(server.parts.has(aggregator)).toBeTruthy();
+  expect(aggregator.lifecycle.isReady).toBeTruthy();
+
+  // Run the server
+  expect(server.lifecycle.isOnline).toBeFalsy();
+
+  // Wait for the server to be online
+  await new Promise<void>((resolve) => {
+    server.lifecycle.online.on(async () => {
+      resolve();
+    });
+    server.start();
+  });
+
+  // Check if the server is online
+  expect(server.lifecycle.isReady).toBeTruthy();
+  expect(server.lifecycle.isOnline).toBeTruthy();
+  expect(server.lifecycle.isCommissioned).toBeFalsy();
+  expect(server.lifecycle.isPartsReady).toBeTruthy();
+  expect(server.lifecycle.hasId).toBeTruthy();
+  expect(server.lifecycle.hasNumber).toBeTruthy();
+  expect(aggregator.lifecycle.isReady).toBeTruthy();
+  expect(aggregator.lifecycle.isInstalled).toBeTruthy();
+  expect(aggregator.lifecycle.isPartsReady).toBeTruthy();
+  expect(aggregator.lifecycle.hasId).toBeTruthy();
+  expect(aggregator.lifecycle.hasNumber).toBeTruthy();
+
+  return [server, aggregator];
+}
+
+/**
+ * Stop a Matterbridge ServerNode.
+ *
+ * @param {ServerNode<ServerNode.RootEndpoint>} server The server to stop.
+ * @returns {Promise<void>} Resolves when the server has stopped.
+ */
+export async function stopServerNode(server: ServerNode<ServerNode.RootEndpoint>): Promise<void> {
+  // Flush any pending endpoint number persistence
+  await flushAllEndpointNumberPersistence(server);
+
+  // Ensure all endpoint numbers are persisted
+  await assertAllEndpointNumbersPersisted(server);
+
+  // Stop the server
+  expect(server).toBeDefined();
+  expect(server.lifecycle.isReady).toBeTruthy();
+  expect(server.lifecycle.isOnline).toBeTruthy();
+  await server.close();
+  expect(server.lifecycle.isReady).toBeTruthy();
+  expect(server.lifecycle.isOnline).toBeFalsy();
+
+  // stop the mDNS service
+  await server.env.get(MdnsService)[Symbol.asyncDispose]();
+
+  // Ensure the queue is empty and pause 100ms
+  await flushAsync();
+}
+
+/**
+ * Add a device (endpoint) to a server or aggregator.
+ *
+ * @param {ServerNode<ServerNode.RootEndpoint> | Endpoint<AggregatorEndpoint>} owner The server or aggregator to add the device to.
+ * @param {Endpoint} device The device to add.
+ * @returns {Promise<void>} Resolves when the device has been added and is ready.
+ */
+export async function addDevice(owner: ServerNode<ServerNode.RootEndpoint> | Endpoint<AggregatorEndpoint>, device: Endpoint): Promise<boolean> {
+  expect(owner).toBeDefined();
+  expect(device).toBeDefined();
+  expect(owner.lifecycle.isReady).toBeTruthy();
+  expect(owner.construction.status).toBe(Lifecycle.Status.Active);
+  expect(owner.lifecycle.isPartsReady).toBeTruthy();
+
+  try {
+    await owner.add(device);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : error;
+    const errorInspect = inspect(error, { depth: 10 });
+    // eslint-disable-next-line no-console
+    console.error(`Error adding device ${device.maybeId}.${device.maybeNumber}: ${errorMessage}\nstack: ${errorInspect}`);
+    return false;
+  }
+  expect(owner.parts.has(device)).toBeTruthy();
+  expect(owner.lifecycle.isPartsReady).toBeTruthy();
+  expect(device.lifecycle.isReady).toBeTruthy();
+  expect(device.lifecycle.isInstalled).toBeTruthy();
+  expect(device.lifecycle.hasId).toBeTruthy();
+  expect(device.lifecycle.hasNumber).toBeTruthy();
+  expect(device.construction.status).toBe(Lifecycle.Status.Active);
+  return true;
+}
+
+/**
+ * Add a device (endpoint) to a server or aggregator.
+ *
+ * @param {ServerNode<ServerNode.RootEndpoint> | Endpoint<AggregatorEndpoint>} owner The server or aggregator to add the device to.
+ * @param {Endpoint} device The device to add.
+ * @returns {Promise<void>} Resolves when the device has been added and is ready.
+ */
+export async function deleteDevice(owner: ServerNode<ServerNode.RootEndpoint> | Endpoint<AggregatorEndpoint>, device: Endpoint): Promise<boolean> {
+  expect(owner).toBeDefined();
+  expect(device).toBeDefined();
+  expect(owner.lifecycle.isReady).toBeTruthy();
+  expect(owner.construction.status).toBe(Lifecycle.Status.Active);
+  expect(owner.lifecycle.isPartsReady).toBeTruthy();
+
+  try {
+    await device.delete();
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : error;
+    const errorInspect = inspect(error, { depth: 10 });
+    // eslint-disable-next-line no-console
+    console.error(`Error deleting device ${device.maybeId}.${device.maybeNumber}: ${errorMessage}\nstack: ${errorInspect}`);
+    return false;
+  }
+  expect(owner.parts.has(device)).toBeFalsy();
+  expect(owner.lifecycle.isPartsReady).toBeTruthy();
+  expect(device.lifecycle.isReady).toBeFalsy();
+  expect(device.lifecycle.isInstalled).toBeFalsy();
+  expect(device.lifecycle.hasId).toBeTruthy();
+  expect(device.lifecycle.hasNumber).toBeTruthy();
+  expect(device.construction.status).toBe(Lifecycle.Status.Destroyed);
+  return true;
+}

--- a/src/mutableDevice.test.ts
+++ b/src/mutableDevice.test.ts
@@ -5,7 +5,6 @@ const NAME = 'MutableDevice';
 const HOMEDIR = path.join('jest', NAME);
 
 import path from 'node:path';
-import { rmSync } from 'node:fs';
 
 import { jest } from '@jest/globals';
 import {
@@ -29,7 +28,6 @@ import {
   smokeCoAlarm,
   thermostatDevice,
   invokeSubscribeHandler,
-  invokeBehaviorCommand,
   roboticVacuumCleaner,
   humiditySensor,
   pressureSensor,
@@ -58,60 +56,14 @@ import {
   FanControl,
 } from 'matterbridge/matter/clusters';
 import { BridgedDeviceBasicInformationServer, LevelControlServer, OnOffServer } from 'matterbridge/matter/behaviors';
-import { Endpoint, Environment, ServerNode, LogLevel as MatterLogLevel, LogFormat as MatterLogFormat, DeviceTypeId, VendorId, MdnsService } from 'matterbridge/matter';
-import { AggregatorEndpoint, RootEndpoint } from 'matterbridge/matter/endpoints';
-import { wait } from 'matterbridge/utils';
+import { Endpoint, Environment, ServerNode } from 'matterbridge/matter';
+import { AggregatorEndpoint } from 'matterbridge/matter/endpoints';
 
 import { MutableDevice } from './mutableDevice.js';
-import { createTestEnvironment, flushAsync } from './jestHelpers.js';
+import { createTestEnvironment, flushAsync, setupTest, startServerNode, stopServerNode } from './jestHelpers.js';
 
-let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
-let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
-let consoleDebugSpy: jest.SpiedFunction<typeof console.log>;
-let consoleInfoSpy: jest.SpiedFunction<typeof console.log>;
-let consoleWarnSpy: jest.SpiedFunction<typeof console.log>;
-let consoleErrorSpy: jest.SpiedFunction<typeof console.log>;
-const debug = false; // Set to true to enable debug logging
-
-if (!debug) {
-  loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
-  consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {});
-  consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation((...args: any[]) => {});
-  consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation((...args: any[]) => {});
-  consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: any[]) => {});
-  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {});
-} else {
-  loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
-  consoleLogSpy = jest.spyOn(console, 'log');
-  consoleDebugSpy = jest.spyOn(console, 'debug');
-  consoleInfoSpy = jest.spyOn(console, 'info');
-  consoleWarnSpy = jest.spyOn(console, 'warn');
-  consoleErrorSpy = jest.spyOn(console, 'error');
-}
-
-function setDebug(debug: boolean) {
-  if (debug) {
-    loggerLogSpy.mockRestore();
-    consoleLogSpy.mockRestore();
-    consoleDebugSpy.mockRestore();
-    consoleInfoSpy.mockRestore();
-    consoleWarnSpy.mockRestore();
-    consoleErrorSpy.mockRestore();
-    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
-    consoleLogSpy = jest.spyOn(console, 'log');
-    consoleDebugSpy = jest.spyOn(console, 'debug');
-    consoleInfoSpy = jest.spyOn(console, 'info');
-    consoleWarnSpy = jest.spyOn(console, 'warn');
-    consoleErrorSpy = jest.spyOn(console, 'error');
-  } else {
-    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
-    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {});
-    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation((...args: any[]) => {});
-    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation((...args: any[]) => {});
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: any[]) => {});
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {});
-  }
-}
+// Setup the test environment
+setupTest(NAME, false);
 
 // Cleanup the matter environment
 createTestEnvironment(HOMEDIR);
@@ -121,13 +73,6 @@ describe('MutableDevice', () => {
   let server: ServerNode<ServerNode.RootEndpoint>;
   let aggregator: Endpoint<AggregatorEndpoint>;
   let device: MatterbridgeEndpoint;
-
-  // Setup the matter environment
-  environment.vars.set('log.level', MatterLogLevel.DEBUG);
-  environment.vars.set('log.format', MatterLogFormat.ANSI);
-  environment.vars.set('path.root', HOMEDIR);
-  environment.vars.set('runtime.signals', false);
-  environment.vars.set('runtime.exitcode', false);
 
   const mockLog = {
     fatal: jest.fn((message: string, ...parameters: any[]) => {}),
@@ -187,68 +132,10 @@ describe('MutableDevice', () => {
     jest.restoreAllMocks();
   });
 
-  test('create the server node', async () => {
-    // Create the server node
-    server = await ServerNode.create({
-      id: NAME + 'ServerNode',
-
-      productDescription: {
-        name: NAME + 'ServerNode',
-        deviceType: DeviceTypeId(RootEndpoint.deviceType),
-        vendorId: VendorId(0xfff1),
-        productId: 0x8000,
-      },
-
-      // Provide defaults for the BasicInformation cluster on the Root endpoint
-      basicInformation: {
-        vendorId: VendorId(0xfff1),
-        vendorName: 'Matterbridge',
-        productId: 0x8000,
-        productName: 'Matterbridge ' + NAME,
-        nodeLabel: NAME + 'ServerNode',
-        hardwareVersion: 1,
-        softwareVersion: 1,
-        reachable: true,
-      },
-
-      network: {
-        port: MATTER_PORT,
-      },
-    });
-    expect(server).toBeDefined();
-    expect(server.lifecycle.isReady).toBeTruthy();
-  });
-
-  test('create the aggregator node', async () => {
-    aggregator = new Endpoint(AggregatorEndpoint, { id: NAME + 'AggregatorNode' });
-    expect(aggregator).toBeDefined();
-  });
-
-  test('add the aggregator node to the server', async () => {
+  test('create and start the server node', async () => {
+    [server, aggregator] = await startServerNode(NAME, MATTER_PORT);
     expect(server).toBeDefined();
     expect(aggregator).toBeDefined();
-    await server.add(aggregator);
-    expect(server.parts.has(aggregator.id)).toBeTruthy();
-    expect(server.parts.has(aggregator)).toBeTruthy();
-    expect(aggregator.lifecycle.isReady).toBeTruthy();
-  });
-
-  test('start the server node', async () => {
-    // Run the server
-    expect(server.lifecycle.isReady).toBeTruthy();
-    expect(server.lifecycle.isOnline).toBeFalsy();
-
-    // Wait for the server to be online
-    await new Promise<void>((resolve) => {
-      server.lifecycle.online.on(async () => {
-        resolve();
-      });
-      server.start();
-    });
-
-    // Check if the server is online
-    expect(server.lifecycle.isReady).toBeTruthy();
-    expect(server.lifecycle.isOnline).toBeTruthy();
   });
 
   it('should initialize with an empty mutableDevice', () => {
@@ -1362,17 +1249,7 @@ describe('MutableDevice', () => {
 
   test('close the server node', async () => {
     expect(server).toBeDefined();
-    expect(server.lifecycle.isReady).toBeTruthy();
-    expect(server.lifecycle.isOnline).toBeTruthy();
-    await server.close();
-    expect(server.lifecycle.isReady).toBeTruthy();
-    expect(server.lifecycle.isOnline).toBeFalsy();
-    // await new Promise((resolve) => setTimeout(resolve, 100));
-  });
-
-  test('stop the mDNS service', async () => {
-    expect(server).toBeDefined();
-    await server.env.get(MdnsService)[Symbol.asyncDispose]();
-    await new Promise((resolve) => setTimeout(resolve, 500)); // Wait for async operations in matter.js to complete and helpers timeout
+    await stopServerNode(server);
+    await flushAsync(1, 1, 500); // wait for helpers timeout
   });
 });

--- a/src/platform.matter.test.ts
+++ b/src/platform.matter.test.ts
@@ -2848,568 +2848,28 @@ describe('Matterbridge ' + NAME, () => {
     // setDebug(false);
   });
 
-  it('should call onStart and register a split entity multi entities device', async () => {
-    const allDomainsDevice = {
+  it('should call onStart and register all split entities', async () => {
+    const hassDevice = {
       id: '560898f83188759ed7329e97df00ee7c',
       name: 'All Domain Device',
     } as unknown as HassDevice;
+    haPlatform.ha.hassDevices.set(hassDevice.id, hassDevice);
 
-    // binary_sensor
-    const batteryLowEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'binary_sensor.battery_low',
-      id: 'battery-low-entity-id',
-      name: 'Battery Low Sensor',
-    } as unknown as HassEntity;
-    const batteryLowState = {
-      entity_id: batteryLowEntity.entity_id,
-      state: 'on', // 'on' = battery low, 'off' = battery okay
-      attributes: { device_class: 'battery', friendly_name: batteryLowEntity.name },
-    } as unknown as HassState;
-
-    const contactEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'binary_sensor.door_contact',
-      id: '0b25a337cb83edefb1d310450ad2b0ac',
-      name: 'Single Entity Contact Sensor',
-    } as unknown as HassEntity;
-    const contactState = {
-      entity_id: contactEntity.entity_id,
-      state: 'on', // 'on' for open, 'off' for closed
-      attributes: { device_class: 'door', friendly_name: contactEntity.name },
-    } as unknown as HassState;
-
-    const windowEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'binary_sensor.window_contact',
-      id: 'window-entity-id',
-      name: 'Window Contact Sensor',
-    } as unknown as HassEntity;
-    const windowState = {
-      entity_id: windowEntity.entity_id,
-      state: 'on', // 'on' = open, 'off' = closed
-      attributes: { device_class: 'window', friendly_name: windowEntity.name },
-    } as unknown as HassState;
-
-    const garageDoorEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'binary_sensor.garage_door_contact',
-      id: 'garage-door-entity-id',
-      name: 'Garage Door Sensor',
-    } as unknown as HassEntity;
-    const garageDoorState = {
-      entity_id: garageDoorEntity.entity_id,
-      state: 'off', // 'on' = open, 'off' = closed
-      attributes: { device_class: 'garage_door', friendly_name: garageDoorEntity.name },
-    } as unknown as HassState;
-
-    const vibrationEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'binary_sensor.vibration_sensor',
-      id: 'vibration-entity-id',
-      name: 'Vibration Sensor',
-    } as unknown as HassEntity;
-    const vibrationState = {
-      entity_id: vibrationEntity.entity_id,
-      state: 'off', // 'on' = vibration detected
-      attributes: { device_class: 'vibration', friendly_name: vibrationEntity.name },
-    } as unknown as HassState;
-
-    const coldEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'binary_sensor.cold_sensor',
-      id: 'cold-entity-id',
-      name: 'Cold Sensor',
-    } as unknown as HassEntity;
-    const coldState = {
-      entity_id: coldEntity.entity_id,
-      state: 'off', // 'on' = cold condition
-      attributes: { device_class: 'cold', friendly_name: coldEntity.name },
-    } as unknown as HassState;
-
-    const moistureEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'binary_sensor.moisture_sensor',
-      id: 'moisture-entity-id',
-      name: 'Moisture Sensor',
-    } as unknown as HassEntity;
-    const moistureState = {
-      entity_id: moistureEntity.entity_id,
-      state: 'off', // 'on' = moisture/leak detected
-      attributes: { device_class: 'moisture', friendly_name: moistureEntity.name },
-    } as unknown as HassState;
-
-    const occupancyEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'binary_sensor.occupancy_sensor',
-      id: 'occupancy-entity-id',
-      name: 'Occupancy Sensor',
-    } as unknown as HassEntity;
-    const occupancyState = {
-      entity_id: occupancyEntity.entity_id,
-      state: 'off', // 'on' = occupied
-      attributes: { device_class: 'occupancy', friendly_name: occupancyEntity.name },
-    } as unknown as HassState;
-
-    const motionEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'binary_sensor.motion_sensor',
-      id: 'motion-entity-id',
-      name: 'Motion Sensor',
-    } as unknown as HassEntity;
-    const motionState = {
-      entity_id: motionEntity.entity_id,
-      state: 'off', // 'on' = motion detected
-      attributes: { device_class: 'motion', friendly_name: motionEntity.name },
-    } as unknown as HassState;
-
-    const presenceEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'binary_sensor.presence_sensor',
-      id: 'presence-entity-id',
-      name: 'Presence Sensor',
-    } as unknown as HassEntity;
-    const presenceStateMulti = {
-      entity_id: presenceEntity.entity_id,
-      state: 'off', // 'on' = presence detected
-      attributes: { device_class: 'presence', friendly_name: presenceEntity.name },
-    } as unknown as HassState;
-
-    const smokeEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'binary_sensor.smoke_sensor_multi',
-      id: 'smoke-entity-id',
-      name: 'Smoke Sensor Multi',
-    } as unknown as HassEntity;
-    const smokeStateMulti = {
-      entity_id: smokeEntity.entity_id,
-      state: 'off', // 'on' = smoke detected
-      attributes: { device_class: 'smoke', friendly_name: smokeEntity.name },
-    } as unknown as HassState;
-
-    const coEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'binary_sensor.co_sensor_multi',
-      id: 'co-entity-id',
-      name: 'CO Sensor Multi',
-    } as unknown as HassEntity;
-    const coStateMulti = {
-      entity_id: coEntity.entity_id,
-      state: 'off', // 'on' = CO detected
-      attributes: { device_class: 'carbon_monoxide', friendly_name: coEntity.name },
-    } as unknown as HassState;
-
-    // sensor
-    const batteryLevelEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.battery_level',
-      id: 'battery-level-entity-id',
-      name: 'Battery Level Sensor',
-    } as unknown as HassEntity;
-    const batteryLevelState = {
-      entity_id: batteryLevelEntity.entity_id,
-      state: '85',
-      attributes: { state_class: 'measurement', device_class: 'battery', unit_of_measurement: '%', friendly_name: batteryLevelEntity.name },
-    } as unknown as HassState;
-
-    const batteryVoltageEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.battery_voltage',
-      id: 'battery-voltage-entity-id',
-      name: 'Battery Voltage Sensor',
-    } as unknown as HassEntity;
-    const batteryVoltageState = {
-      entity_id: batteryVoltageEntity.entity_id,
-      state: '3.7',
-      attributes: { state_class: 'measurement', device_class: 'voltage', unit_of_measurement: 'V', friendly_name: batteryVoltageEntity.name },
-    } as unknown as HassState;
-
-    const temperatureEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.temperature',
-      id: 'temperature-entity-id',
-      name: 'Temperature Sensor',
-    } as unknown as HassEntity;
-    const temperatureState = {
-      entity_id: temperatureEntity.entity_id,
-      state: '22.6',
-      attributes: { state_class: 'measurement', device_class: 'temperature', unit_of_measurement: '°C', friendly_name: temperatureEntity.name },
-    } as unknown as HassState;
-
-    const humidityEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.humidity',
-      id: 'humidity-entity-id',
-      name: 'Humidity Sensor',
-    } as unknown as HassEntity;
-    const humidityState = {
-      entity_id: humidityEntity.entity_id,
-      state: '56.3',
-      attributes: { state_class: 'measurement', device_class: 'humidity', unit_of_measurement: '%', friendly_name: humidityEntity.name },
-    } as unknown as HassState;
-
-    const pressureEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.pressure',
-      id: 'pressure-entity-id',
-      name: 'Pressure Sensor',
-    } as unknown as HassEntity;
-    const pressureState = {
-      entity_id: pressureEntity.entity_id,
-      state: '1013',
-      attributes: { state_class: 'measurement', device_class: 'pressure', unit_of_measurement: 'hPa', friendly_name: pressureEntity.name },
-    } as unknown as HassState;
-
-    const atmosphericPressureEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.atmospheric_pressure',
-      id: 'atmospheric-pressure-entity-id',
-      name: 'Atmospheric Pressure Sensor',
-    } as unknown as HassEntity;
-    const atmosphericPressureState = {
-      entity_id: atmosphericPressureEntity.entity_id,
-      state: '1013',
-      attributes: { state_class: 'measurement', device_class: 'atmospheric_pressure', unit_of_measurement: 'hPa', friendly_name: atmosphericPressureEntity.name },
-    } as unknown as HassState;
-
-    const illuminanceEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.illuminance',
-      id: 'illuminance-entity-id',
-      name: 'Illuminance Sensor',
-    } as unknown as HassEntity;
-    const illuminanceState = {
-      entity_id: illuminanceEntity.entity_id,
-      state: '500',
-      attributes: { state_class: 'measurement', device_class: 'illuminance', unit_of_measurement: 'lx', friendly_name: illuminanceEntity.name },
-    } as unknown as HassState;
-
-    const energyEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.energy_total',
-      id: 'energy-entity-id',
-      name: 'Energy Total Sensor',
-    } as unknown as HassEntity;
-    const energyState = {
-      entity_id: energyEntity.entity_id,
-      state: '12.34',
-      attributes: { state_class: 'total_increasing', device_class: 'energy', unit_of_measurement: 'kWh', friendly_name: energyEntity.name },
-    } as unknown as HassState;
-
-    const powerEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.power',
-      id: 'power-entity-id',
-      name: 'Power Sensor',
-    } as unknown as HassEntity;
-    const powerState = {
-      entity_id: powerEntity.entity_id,
-      state: '100',
-      attributes: { state_class: 'measurement', device_class: 'power', unit_of_measurement: 'W', friendly_name: powerEntity.name },
-    } as unknown as HassState;
-
-    const currentEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.current',
-      id: 'current-entity-id',
-      name: 'Current Sensor',
-    } as unknown as HassEntity;
-    const currentState = {
-      entity_id: currentEntity.entity_id,
-      state: '0.5',
-      attributes: { state_class: 'measurement', device_class: 'current', unit_of_measurement: 'A', friendly_name: currentEntity.name },
-    } as unknown as HassState;
-
-    const voltageEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.voltage',
-      id: 'voltage-entity-id',
-      name: 'Voltage Sensor',
-    } as unknown as HassEntity;
-    const voltageState = {
-      entity_id: voltageEntity.entity_id,
-      state: '230',
-      attributes: { state_class: 'measurement', device_class: 'voltage', unit_of_measurement: 'V', friendly_name: voltageEntity.name },
-    } as unknown as HassState;
-
-    const aqiEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.air_quality',
-      id: 'aqi-entity-id',
-      name: 'Air Quality Sensor Multi',
-    } as unknown as HassEntity;
-    const aqiState = {
-      entity_id: aqiEntity.entity_id,
-      state: 'fair',
-      attributes: { state_class: 'measurement', device_class: 'aqi', friendly_name: aqiEntity.name },
-    } as unknown as HassState;
-
-    const vocEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.voc',
-      id: 'voc-entity-id',
-      name: 'VOC Sensor',
-    } as unknown as HassEntity;
-    const vocState = {
-      entity_id: vocEntity.entity_id,
-      state: '100',
-      attributes: { state_class: 'measurement', device_class: 'volatile_organic_compounds', friendly_name: vocEntity.name },
-    } as unknown as HassState;
-
-    const vocPartsEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.voc_parts',
-      id: 'voc-parts-entity-id',
-      name: 'VOC Parts Sensor',
-    } as unknown as HassEntity;
-    const vocPartsState = {
-      entity_id: vocPartsEntity.entity_id,
-      state: '150',
-      attributes: { state_class: 'measurement', device_class: 'volatile_organic_compounds_parts', friendly_name: vocPartsEntity.name },
-    } as unknown as HassState;
-
-    const co2Entity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.co2',
-      id: 'co2-entity-id',
-      name: 'CO2 Sensor',
-    } as unknown as HassEntity;
-    const co2State = {
-      entity_id: co2Entity.entity_id,
-      state: '600',
-      attributes: { state_class: 'measurement', device_class: 'carbon_dioxide', friendly_name: co2Entity.name },
-    } as unknown as HassState;
-
-    const coSensorEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.co_multi',
-      id: 'co-sensor-entity-id',
-      name: 'CO Sensor Multi Level',
-    } as unknown as HassEntity;
-    const coSensorState = {
-      entity_id: coSensorEntity.entity_id,
-      state: '30',
-      attributes: { state_class: 'measurement', device_class: 'carbon_monoxide', friendly_name: coSensorEntity.name },
-    } as unknown as HassState;
-
-    const no2Entity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.no2',
-      id: 'no2-entity-id',
-      name: 'NO2 Sensor',
-    } as unknown as HassEntity;
-    const no2State = {
-      entity_id: no2Entity.entity_id,
-      state: '15',
-      attributes: { state_class: 'measurement', device_class: 'nitrogen_dioxide', friendly_name: no2Entity.name },
-    } as unknown as HassState;
-
-    const ozoneEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.ozone',
-      id: 'ozone-entity-id',
-      name: 'Ozone Sensor',
-    } as unknown as HassEntity;
-    const ozoneState = {
-      entity_id: ozoneEntity.entity_id,
-      state: '5',
-      attributes: { state_class: 'measurement', device_class: 'ozone', friendly_name: ozoneEntity.name },
-    } as unknown as HassState;
-
-    const formaldehydeEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.formaldehyde',
-      id: 'formaldehyde-entity-id',
-      name: 'Formaldehyde Sensor',
-    } as unknown as HassEntity;
-    const formaldehydeState = {
-      entity_id: formaldehydeEntity.entity_id,
-      state: '2',
-      attributes: { state_class: 'measurement', device_class: 'formaldehyde', friendly_name: formaldehydeEntity.name },
-    } as unknown as HassState;
-
-    const radonEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.radon',
-      id: 'radon-entity-id',
-      name: 'Radon Sensor',
-    } as unknown as HassEntity;
-    const radonState = {
-      entity_id: radonEntity.entity_id,
-      state: '50',
-      attributes: { state_class: 'measurement', device_class: 'radon', friendly_name: radonEntity.name },
-    } as unknown as HassState;
-
-    const pm1Entity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.pm1',
-      id: 'pm1-entity-id',
-      name: 'PM1 Sensor',
-    } as unknown as HassEntity;
-    const pm1State = {
-      entity_id: pm1Entity.entity_id,
-      state: '5',
-      attributes: { state_class: 'measurement', device_class: 'pm1', friendly_name: pm1Entity.name },
-    } as unknown as HassState;
-
-    const pm25Entity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.pm25',
-      id: 'pm25-entity-id',
-      name: 'PM2.5 Sensor',
-    } as unknown as HassEntity;
-    const pm25State = {
-      entity_id: pm25Entity.entity_id,
-      state: '12',
-      attributes: { state_class: 'measurement', device_class: 'pm25', friendly_name: pm25Entity.name },
-    } as unknown as HassState;
-
-    const pm10Entity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'sensor.pm10',
-      id: 'pm10-entity-id',
-      name: 'PM10 Sensor',
-    } as unknown as HassEntity;
-    const pm10State = {
-      entity_id: pm10Entity.entity_id,
-      state: '20',
-      attributes: { state_class: 'measurement', device_class: 'pm10', friendly_name: pm10Entity.name },
-    } as unknown as HassState;
-
-    // control
-    const switchEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'switch.template_switch',
-      id: '0b25a337cb83edefb1d310450ad2b0ac',
-      name: 'Single Entity Switch',
-    } as unknown as HassEntity;
-    const switchState = {
-      entity_id: switchEntity.entity_id,
-      state: 'on',
-      attributes: { friendly_name: switchEntity.name },
-    } as unknown as HassState;
-
-    const lightOnOffEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'light.template_light_onoff',
-      id: 'light-entity-id',
-      name: 'Single Entity Light OnOff',
-    } as unknown as HassEntity;
-    const lightOnOffState = {
-      entity_id: lightOnOffEntity.entity_id,
-      state: 'on',
-      attributes: { friendly_name: lightOnOffEntity.name },
-    } as unknown as HassState;
-
-    const lightDimmerEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'light.template_light_dimmer',
-      id: 'light-entity-id',
-      name: 'Single Entity Light Dimmer',
-    } as unknown as HassEntity;
-    const lightDimmerState = {
-      entity_id: lightDimmerEntity.entity_id,
-      state: 'on',
-      attributes: { friendly_name: lightDimmerEntity.name, brightness: 150 },
-    } as unknown as HassState;
-
-    // lock
-    const lockEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'lock.template_lock',
-      id: 'lock-entity-id',
-      name: 'Single Entity Lock',
-    } as unknown as HassEntity;
-    const lockState = {
-      entity_id: lockEntity.entity_id,
-      state: 'locked',
-      attributes: { friendly_name: lockEntity.name },
-    } as unknown as HassState;
-
-    // valve
-    const valveEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'valve.template_valve',
-      id: 'valve-entity-id',
-      name: 'Single Entity Valve',
-    } as unknown as HassEntity;
-    const valveState = {
-      entity_id: valveEntity.entity_id,
-      state: 'open',
-      attributes: { friendly_name: valveEntity.name, current_position: 50 },
-    } as unknown as HassState;
-
-    // vacuum
-    const vacuumEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'vacuum.template_vacuum',
-      id: 'vacuum-entity-id',
-      name: 'Single Entity Vacuum',
-    } as unknown as HassEntity;
-    const vacuumState = {
-      entity_id: vacuumEntity.entity_id,
-      state: 'docked',
-      attributes: { friendly_name: vacuumEntity.name },
-    } as unknown as HassState;
-
-    // fan
-    const fanEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'fan.template_fan',
-      id: 'fan-entity-id',
-      name: 'Single Entity Fan',
-    } as unknown as HassEntity;
-    const fanState = {
-      entity_id: fanEntity.entity_id,
-      state: 'on',
-      attributes: { friendly_name: fanEntity.name, percentage: 50, direction: 'forward' },
-    } as unknown as HassState;
-
-    // climate
-    const climateEntity = {
-      device_id: allDomainsDevice.id,
-      entity_id: 'climate.template_climate',
-      id: 'climate-entity-id',
-      name: 'Single Entity Climate',
-    } as unknown as HassEntity;
-    const climateState = {
-      entity_id: climateEntity.entity_id,
-      state: 'heat_cool',
-      attributes: {
-        friendly_name: climateEntity.name,
-        hvac_modes: ['off', 'heat', 'cool', 'heat_cool'],
-        target_temp_low: 20,
-        target_temp_high: 24,
-        current_temperature: 22,
-        min_temp: 5,
-        max_temp: 35,
-      },
-    } as unknown as HassState;
-
-    haPlatform.ha.hassDevices.set(allDomainsDevice.id, allDomainsDevice);
-
-    // binary_sensor (refactored similar to sensorEntities below)
-    const binarySensorEntities: [HassEntity, HassState][] = [
-      [batteryLowEntity, batteryLowState],
-      [contactEntity, contactState],
-      [windowEntity, windowState],
-      [garageDoorEntity, garageDoorState],
-      [vibrationEntity, vibrationState],
-      [coldEntity, coldState],
-      [moistureEntity, moistureState],
-      [occupancyEntity, occupancyState],
-      [motionEntity, motionState],
-      [presenceEntity, presenceStateMulti],
-      [smokeEntity, smokeStateMulti],
-      [coEntity, coStateMulti],
-    ];
-    for (const [e, s] of binarySensorEntities) {
-      haPlatform.ha.hassEntities.set(e.entity_id, e);
-      haPlatform.ha.hassStates.set(s.entity_id, s);
-    }
-
-    // sensor
-    const sensorEntities: [HassEntity, HassState][] = [
+    const entities: [HassEntity, HassState][] = [
+      // controls
+      [switchEntity, switchState],
+      [lightOnOffEntity, lightOnOffState],
+      [lightDimmerEntity, lightDimmerState],
+      [lightCtEntity, lightCtState],
+      [lockEntity, lockState],
+      [valveEntity, valveState],
+      [vacuumEntity, vacuumState],
+      [fanEntity, fanState],
+      [fanCompleteEntity, fanCompleteState],
+      [climateEntity, climateState],
+      [climateHeatEntity, climateHeatState],
+      [climateCoolEntity, climateCoolState],
+      // sensor
       [batteryLevelEntity, batteryLevelState],
       [batteryVoltageEntity, batteryVoltageState],
       [temperatureEntity, temperatureState],
@@ -3433,36 +2893,25 @@ describe('Matterbridge ' + NAME, () => {
       [pm1Entity, pm1State],
       [pm25Entity, pm25State],
       [pm10Entity, pm10State],
-    ];
-    for (const [e, s] of sensorEntities) {
-      haPlatform.ha.hassEntities.set(e.entity_id, e);
-      haPlatform.ha.hassStates.set(s.entity_id, s);
-    }
-
-    // controls
-    const controlEntities: [HassEntity, HassState][] = [
-      [switchEntity, switchState],
-      [lightOnOffEntity, lightOnOffState],
-      [lightDimmerEntity, lightDimmerState],
-      [lockEntity, lockState],
-      [valveEntity, valveState],
-      [vacuumEntity, vacuumState],
-      [fanEntity, fanState],
-      [climateEntity, climateState],
-    ];
-    for (const [e, s] of controlEntities) {
-      haPlatform.ha.hassEntities.set(e.entity_id, e);
-      haPlatform.ha.hassStates.set(s.entity_id, s);
-    }
-
-    haPlatform.config.splitEntities = [
       // binary_sensor
-      ...binarySensorEntities.map(([e]) => e.entity_id),
-      // sensor
-      ...sensorEntities.map(([e]) => e.entity_id),
-      // controls
-      ...controlEntities.map(([e]) => e.entity_id),
+      [batteryLowEntity, batteryLowState],
+      [contactEntity, contactState],
+      [windowEntity, windowState],
+      [garageDoorEntity, garageDoorState],
+      [vibrationEntity, vibrationState],
+      [coldEntity, coldState],
+      [moistureEntity, moistureState],
+      [occupancyEntity, occupancyState],
+      [motionEntity, motionState],
+      [presenceEntity, presenceStateMulti],
+      [smokeEntity, smokeStateMulti],
+      [coEntity, coStateMulti],
     ];
+    for (const [e, s] of entities) {
+      haPlatform.ha.hassEntities.set(e.entity_id, { ...e, device_id: hassDevice.id });
+      haPlatform.ha.hassStates.set(s.entity_id, s);
+    }
+    haPlatform.config.splitEntities = [...entities.map(([e]) => e.entity_id)];
 
     // setDebug(true);
 
@@ -3472,8 +2921,8 @@ describe('Matterbridge ' + NAME, () => {
     expect(mockMatterbridge.addBridgedEndpoint).toHaveBeenCalledTimes((haPlatform.config.splitEntities as string[]).length);
     expect(haPlatform.matterbridgeDevices.size).toBe((haPlatform.config.splitEntities as string[]).length);
     expect(aggregator.parts.size).toBe((haPlatform.config.splitEntities as string[]).length);
-    expect(addCommandHandlerSpy).toHaveBeenCalledTimes(31); // switch(3) + lightOnOff(10) + lightDimmer(10) + lock(2) + valve(2) + vacuum(4) + fan(0) + climate(0)
-    expect(subscribeAttributeSpy).toHaveBeenCalledTimes(7); // fan(4) + climate(3)
+    expect(addCommandHandlerSpy).toHaveBeenCalledTimes(41); // switch(3) + lightOnOff(10) + lightDimmer(10) + lightCt(10) + lock(2) + valve(2) + vacuum(4) + fan(0) + climate(0)
+    expect(subscribeAttributeSpy).toHaveBeenCalledTimes(13); // fan(2) + fanComplete(4) + climateHeatCool(3) + climateHeat(2) + climateCool(2)
 
     for (const device of haPlatform.matterbridgeDevices.values()) {
       expect(device.getChildEndpoints().length).toBe(0); // No child endpoints for individual entities. All remapped to main.
@@ -3481,6 +2930,7 @@ describe('Matterbridge ' + NAME, () => {
     expect(haPlatform.matterbridgeDevices.get(contactEntity.entity_id)?.getAttribute(BooleanState.Cluster.id, 'stateValue')).toBe(false); // Contact Sensor: true = closed or contact, false = open or no contact
     expect(addClusterServerBooleanStateSpy).toHaveBeenCalledWith(contactEntity.entity_id, false);
 
+    // No warnings or errors
     expect(mockLog.warn).not.toHaveBeenCalled();
     expect(mockLog.error).not.toHaveBeenCalled();
     expect(mockLog.fatal).not.toHaveBeenCalled();
@@ -3494,6 +2944,7 @@ describe('Matterbridge ' + NAME, () => {
     await haPlatform.onConfigure();
     expect(setAttributeSpy.mock.calls.length).toBeGreaterThanOrEqual((haPlatform.config.splitEntities as string[]).length);
 
+    // No warnings or errors
     expect(mockLog.warn).not.toHaveBeenCalled();
     expect(mockLog.error).not.toHaveBeenCalled();
     expect(mockLog.fatal).not.toHaveBeenCalled();
@@ -3547,7 +2998,11 @@ describe('Matterbridge ' + NAME, () => {
     // control entities
     expect(haPlatform.matterbridgeDevices.get(switchEntity.entity_id)?.getAttribute(OnOff.Cluster.id, 'onOff')).toBe(true);
     expect(haPlatform.matterbridgeDevices.get(lightOnOffEntity.entity_id)?.getAttribute(OnOff.Cluster.id, 'onOff')).toBe(true);
+    expect(haPlatform.matterbridgeDevices.get(lightDimmerEntity.entity_id)?.getAttribute(OnOff.Cluster.id, 'onOff')).toBe(true);
     expect(haPlatform.matterbridgeDevices.get(lightDimmerEntity.entity_id)?.getAttribute(LevelControl.Cluster.id, 'currentLevel')).toBe(149); // brightness 150 -> ~149
+    expect(haPlatform.matterbridgeDevices.get(lightCtEntity.entity_id)?.getAttribute(OnOff.Cluster.id, 'onOff')).toBe(true);
+    expect(haPlatform.matterbridgeDevices.get(lightCtEntity.entity_id)?.getAttribute(LevelControl.Cluster.id, 'currentLevel')).toBe(100); // brightness 150 -> ~149
+    expect(haPlatform.matterbridgeDevices.get(lightCtEntity.entity_id)?.getAttribute(ColorControl.Cluster.id, 'colorTemperatureMireds')).toBe(500);
     expect(haPlatform.matterbridgeDevices.get(lockEntity.entity_id)?.getAttribute(DoorLock.Cluster.id, 'lockState')).toBe(DoorLock.LockState.Locked);
     expect(haPlatform.matterbridgeDevices.get(valveEntity.entity_id)?.getAttribute(ValveConfigurationAndControl.Cluster.id, 'currentState')).toBe(
       ValveConfigurationAndControl.ValveState.Open,
@@ -3558,7 +3013,210 @@ describe('Matterbridge ' + NAME, () => {
       RvcOperationalState.OperationalState.Docked,
     );
     expect(haPlatform.matterbridgeDevices.get(fanEntity.entity_id)?.getAttribute(FanControl.Cluster.id, 'fanMode')).toBe(FanControl.FanMode.Auto);
+    expect(haPlatform.matterbridgeDevices.get(fanEntity.entity_id)?.getAttribute(FanControl.Cluster.id, 'percentCurrent')).toBe(50);
+    expect(haPlatform.matterbridgeDevices.get(fanCompleteEntity.entity_id)?.getAttribute(FanControl.Cluster.id, 'fanMode')).toBe(FanControl.FanMode.Auto);
+    expect(haPlatform.matterbridgeDevices.get(fanCompleteEntity.entity_id)?.getAttribute(FanControl.Cluster.id, 'percentCurrent')).toBe(50);
+    expect(haPlatform.matterbridgeDevices.get(fanCompleteEntity.entity_id)?.getAttribute(FanControl.Cluster.id, 'airflowDirection')).toBe(FanControl.AirflowDirection.Forward);
+    expect(haPlatform.matterbridgeDevices.get(fanCompleteEntity.entity_id)?.getAttribute(FanControl.Cluster.id, 'rockSetting')).toEqual({
+      rockLeftRight: false,
+      rockRound: true,
+      rockUpDown: false,
+    });
     expect(haPlatform.matterbridgeDevices.get(climateEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'systemMode')).toBe(Thermostat.SystemMode.Auto);
+    expect(haPlatform.matterbridgeDevices.get(climateEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'occupiedHeatingSetpoint')).toBe(2000);
+    expect(haPlatform.matterbridgeDevices.get(climateEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'occupiedCoolingSetpoint')).toBe(2400);
+    expect(haPlatform.matterbridgeDevices.get(climateEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'localTemperature')).toBe(2200);
+    expect(haPlatform.matterbridgeDevices.get(climateHeatEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'systemMode')).toBe(Thermostat.SystemMode.Heat);
+    expect(haPlatform.matterbridgeDevices.get(climateHeatEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'occupiedHeatingSetpoint')).toBe(2000);
+    expect(haPlatform.matterbridgeDevices.get(climateHeatEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'localTemperature')).toBe(2200);
+    expect(haPlatform.matterbridgeDevices.get(climateCoolEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'systemMode')).toBe(Thermostat.SystemMode.Cool);
+    expect(haPlatform.matterbridgeDevices.get(climateCoolEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'occupiedCoolingSetpoint')).toBe(2000);
+    expect(haPlatform.matterbridgeDevices.get(climateCoolEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'localTemperature')).toBe(1800);
+
+    // Clean the test environment
+    await cleanup();
+
+    // setDebug(false);
+  });
+
+  it('should call onStart and register all individual entities', async () => {
+    const entities: [HassEntity, HassState][] = [
+      // controls
+      [switchEntity, switchState],
+      [lightOnOffEntity, lightOnOffState],
+      [lightDimmerEntity, lightDimmerState],
+      [lightCtEntity, lightCtState],
+      [lockEntity, lockState],
+      [valveEntity, valveState],
+      [vacuumEntity, vacuumState],
+      [fanEntity, fanState],
+      [fanCompleteEntity, fanCompleteState],
+      [climateEntity, climateState],
+      [climateHeatEntity, climateHeatState],
+      [climateCoolEntity, climateCoolState],
+      // sensor
+      [batteryLevelEntity, batteryLevelState],
+      [batteryVoltageEntity, batteryVoltageState],
+      [temperatureEntity, temperatureState],
+      [humidityEntity, humidityState],
+      [pressureEntity, pressureState],
+      [atmosphericPressureEntity, atmosphericPressureState],
+      [illuminanceEntity, illuminanceState],
+      [energyEntity, energyState],
+      [powerEntity, powerState],
+      [currentEntity, currentState],
+      [voltageEntity, voltageState],
+      [aqiEntity, aqiState],
+      [vocEntity, vocState],
+      [vocPartsEntity, vocPartsState],
+      [co2Entity, co2State],
+      [coSensorEntity, coSensorState],
+      [no2Entity, no2State],
+      [ozoneEntity, ozoneState],
+      [formaldehydeEntity, formaldehydeState],
+      [radonEntity, radonState],
+      [pm1Entity, pm1State],
+      [pm25Entity, pm25State],
+      [pm10Entity, pm10State],
+      // binary_sensor
+      [batteryLowEntity, batteryLowState],
+      [contactEntity, contactState],
+      [windowEntity, windowState],
+      [garageDoorEntity, garageDoorState],
+      [vibrationEntity, vibrationState],
+      [coldEntity, coldState],
+      [moistureEntity, moistureState],
+      [occupancyEntity, occupancyState],
+      [motionEntity, motionState],
+      [presenceEntity, presenceStateMulti],
+      [smokeEntity, smokeStateMulti],
+      [coEntity, coStateMulti],
+    ];
+    for (const [e, s] of entities) {
+      haPlatform.ha.hassEntities.set(e.entity_id, { ...e });
+      haPlatform.ha.hassStates.set(s.entity_id, s);
+    }
+    haPlatform.config.splitEntities = [...entities.map(([e]) => e.entity_id)];
+
+    // setDebug(true);
+
+    await haPlatform.onStart('Test reason');
+    await flushAsync(); // ensure all split entity devices created
+    expect(mockLog.info).toHaveBeenCalledWith(`Starting platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);
+    expect(mockMatterbridge.addBridgedEndpoint).toHaveBeenCalledTimes((haPlatform.config.splitEntities as string[]).length);
+    expect(haPlatform.matterbridgeDevices.size).toBe((haPlatform.config.splitEntities as string[]).length);
+    expect(aggregator.parts.size).toBe((haPlatform.config.splitEntities as string[]).length);
+    expect(addCommandHandlerSpy).toHaveBeenCalledTimes(41); // switch(3) + lightOnOff(10) + lightDimmer(10) + lightCt(10) + lock(2) + valve(2) + vacuum(4) + fan(0) + climate(0)
+    expect(subscribeAttributeSpy).toHaveBeenCalledTimes(13); // fan(2) + fanComplete(4) + climateHeatCool(3) + climateHeat(2) + climateCool(2)
+
+    for (const device of haPlatform.matterbridgeDevices.values()) {
+      expect(device.getChildEndpoints().length).toBe(0); // No child endpoints for individual entities. All remapped to main.
+    }
+    expect(haPlatform.matterbridgeDevices.get(contactEntity.entity_id)?.getAttribute(BooleanState.Cluster.id, 'stateValue')).toBe(false); // Contact Sensor: true = closed or contact, false = open or no contact
+    expect(addClusterServerBooleanStateSpy).toHaveBeenCalledWith(contactEntity.entity_id, false);
+
+    // No warnings or errors
+    expect(mockLog.warn).not.toHaveBeenCalled();
+    expect(mockLog.error).not.toHaveBeenCalled();
+    expect(mockLog.fatal).not.toHaveBeenCalled();
+    expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.WARN, expect.anything());
+    expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.ERROR, expect.anything());
+    expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.FATAL, expect.anything());
+
+    jest.clearAllMocks();
+    haPlatform.batteryVoltageEntities.clear();
+    haPlatform.batteryVoltageEntities.add(batteryVoltageEntity.entity_id); // Is mixed here so we set manually
+    await haPlatform.onConfigure();
+    expect(setAttributeSpy.mock.calls.length).toBeGreaterThanOrEqual((haPlatform.config.splitEntities as string[]).length);
+
+    // No warnings or errors
+    expect(mockLog.warn).not.toHaveBeenCalled();
+    expect(mockLog.error).not.toHaveBeenCalled();
+    expect(mockLog.fatal).not.toHaveBeenCalled();
+    expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.WARN, expect.anything());
+    expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.ERROR, expect.anything());
+    expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.FATAL, expect.anything());
+
+    // binary_sensor entities
+    expect(haPlatform.matterbridgeDevices.get(batteryLowEntity.entity_id)?.getAttribute(PowerSource.Cluster.id, 'batChargeLevel')).toBe(PowerSource.BatChargeLevel.Critical); // Battery Low: true = low, false = normal
+    expect(haPlatform.matterbridgeDevices.get(contactEntity.entity_id)?.getAttribute(BooleanState.Cluster.id, 'stateValue')).toBe(false); // Contact Sensor: true = closed or contact, false = open or no contact
+    expect(haPlatform.matterbridgeDevices.get(windowEntity.entity_id)?.getAttribute(BooleanState.Cluster.id, 'stateValue')).toBe(false); // window open -> false
+    expect(haPlatform.matterbridgeDevices.get(garageDoorEntity.entity_id)?.getAttribute(BooleanState.Cluster.id, 'stateValue')).toBe(true); // garage door closed -> true
+    expect(haPlatform.matterbridgeDevices.get(vibrationEntity.entity_id)?.getAttribute(BooleanState.Cluster.id, 'stateValue')).toBe(true); // vibration off -> true (no vibration)
+    expect(haPlatform.matterbridgeDevices.get(coldEntity.entity_id)?.getAttribute(BooleanState.Cluster.id, 'stateValue')).toBe(false); // cold off -> false
+    expect(haPlatform.matterbridgeDevices.get(moistureEntity.entity_id)?.getAttribute(BooleanState.Cluster.id, 'stateValue')).toBe(false); // moisture off -> false
+    expect(haPlatform.matterbridgeDevices.get(occupancyEntity.entity_id)?.getAttribute(OccupancySensing.Cluster.id, 'occupancy')).toEqual({ occupied: false });
+    expect(haPlatform.matterbridgeDevices.get(motionEntity.entity_id)?.getAttribute(OccupancySensing.Cluster.id, 'occupancy')).toEqual({ occupied: false });
+    expect(haPlatform.matterbridgeDevices.get(presenceEntity.entity_id)?.getAttribute(OccupancySensing.Cluster.id, 'occupancy')).toEqual({ occupied: false });
+    expect(haPlatform.matterbridgeDevices.get(smokeEntity.entity_id)?.getAttribute(SmokeCoAlarm.Cluster.id, 'smokeState')).toBe(SmokeCoAlarm.AlarmState.Normal);
+    expect(haPlatform.matterbridgeDevices.get(coEntity.entity_id)?.getAttribute(SmokeCoAlarm.Cluster.id, 'coState')).toBe(SmokeCoAlarm.AlarmState.Normal);
+
+    // sensor entities
+    expect(haPlatform.matterbridgeDevices.get(batteryLevelEntity.entity_id)?.getAttribute(PowerSource.Cluster.id, 'batPercentRemaining')).toBe(170); // 85% *2
+    expect(haPlatform.matterbridgeDevices.get(batteryVoltageEntity.entity_id)?.getAttribute(PowerSource.Cluster.id, 'batVoltage')).toBe(3700); // 3.7V -> 3700mV
+    expect(haPlatform.matterbridgeDevices.get(temperatureEntity.entity_id)?.getAttribute(TemperatureMeasurement.Cluster.id, 'measuredValue')).toBe(2260); // 22.6C *100
+    expect(haPlatform.matterbridgeDevices.get(humidityEntity.entity_id)?.getAttribute(RelativeHumidityMeasurement.Cluster.id, 'measuredValue')).toBe(5630); // 56.3% *100
+    expect(haPlatform.matterbridgeDevices.get(pressureEntity.entity_id)?.getAttribute(PressureMeasurement.Cluster.id, 'measuredValue')).toBe(1013);
+    expect(haPlatform.matterbridgeDevices.get(atmosphericPressureEntity.entity_id)?.getAttribute(PressureMeasurement.Cluster.id, 'measuredValue')).toBe(1013);
+    expect(haPlatform.matterbridgeDevices.get(illuminanceEntity.entity_id)?.getAttribute(IlluminanceMeasurement.Cluster.id, 'measuredValue')).toBe(26990);
+    // PowerEnergy block
+    expect(haPlatform.matterbridgeDevices.get(energyEntity.entity_id)?.getAttribute(ElectricalEnergyMeasurement.Cluster.id, 'cumulativeEnergyImported')).toEqual({
+      energy: 12340000,
+    });
+    expect(haPlatform.matterbridgeDevices.get(powerEntity.entity_id)?.getAttribute(ElectricalPowerMeasurement.Cluster.id, 'activePower')).toBe(100000);
+    expect(haPlatform.matterbridgeDevices.get(currentEntity.entity_id)?.getAttribute(ElectricalPowerMeasurement.Cluster.id, 'activeCurrent')).toBe(500);
+    expect(haPlatform.matterbridgeDevices.get(voltageEntity.entity_id)?.getAttribute(ElectricalPowerMeasurement.Cluster.id, 'voltage')).toBe(230000);
+    // Air quality block
+    expect(haPlatform.matterbridgeDevices.get(aqiEntity.entity_id)?.getAttribute(AirQuality.Cluster.id, 'airQuality')).toBe(AirQuality.AirQualityEnum.Fair);
+    expect(haPlatform.matterbridgeDevices.get(vocEntity.entity_id)?.getAttribute(TotalVolatileOrganicCompoundsConcentrationMeasurement.Cluster.id, 'measuredValue')).toBe(100);
+    expect(haPlatform.matterbridgeDevices.get(vocPartsEntity.entity_id)?.getAttribute(TotalVolatileOrganicCompoundsConcentrationMeasurement.Cluster.id, 'measuredValue')).toBe(150);
+    expect(haPlatform.matterbridgeDevices.get(co2Entity.entity_id)?.getAttribute(CarbonDioxideConcentrationMeasurement.Cluster.id, 'measuredValue')).toBe(600);
+    expect(haPlatform.matterbridgeDevices.get(coSensorEntity.entity_id)?.getAttribute(CarbonMonoxideConcentrationMeasurement.Cluster.id, 'measuredValue')).toBe(30);
+    expect(haPlatform.matterbridgeDevices.get(no2Entity.entity_id)?.getAttribute(NitrogenDioxideConcentrationMeasurement.Cluster.id, 'measuredValue')).toBe(15);
+    expect(haPlatform.matterbridgeDevices.get(ozoneEntity.entity_id)?.getAttribute(OzoneConcentrationMeasurement.Cluster.id, 'measuredValue')).toBe(5);
+    expect(haPlatform.matterbridgeDevices.get(formaldehydeEntity.entity_id)?.getAttribute(FormaldehydeConcentrationMeasurement.Cluster.id, 'measuredValue')).toBe(2);
+    expect(haPlatform.matterbridgeDevices.get(radonEntity.entity_id)?.getAttribute(RadonConcentrationMeasurement.Cluster.id, 'measuredValue')).toBe(50);
+    expect(haPlatform.matterbridgeDevices.get(pm1Entity.entity_id)?.getAttribute(Pm1ConcentrationMeasurement.Cluster.id, 'measuredValue')).toBe(5);
+    expect(haPlatform.matterbridgeDevices.get(pm25Entity.entity_id)?.getAttribute(Pm25ConcentrationMeasurement.Cluster.id, 'measuredValue')).toBe(12);
+    expect(haPlatform.matterbridgeDevices.get(pm10Entity.entity_id)?.getAttribute(Pm10ConcentrationMeasurement.Cluster.id, 'measuredValue')).toBe(20);
+
+    // control entities
+    expect(haPlatform.matterbridgeDevices.get(switchEntity.entity_id)?.getAttribute(OnOff.Cluster.id, 'onOff')).toBe(true);
+    expect(haPlatform.matterbridgeDevices.get(lightOnOffEntity.entity_id)?.getAttribute(OnOff.Cluster.id, 'onOff')).toBe(true);
+    expect(haPlatform.matterbridgeDevices.get(lightDimmerEntity.entity_id)?.getAttribute(OnOff.Cluster.id, 'onOff')).toBe(true);
+    expect(haPlatform.matterbridgeDevices.get(lightDimmerEntity.entity_id)?.getAttribute(LevelControl.Cluster.id, 'currentLevel')).toBe(149); // brightness 150 -> ~149
+    expect(haPlatform.matterbridgeDevices.get(lightCtEntity.entity_id)?.getAttribute(OnOff.Cluster.id, 'onOff')).toBe(true);
+    expect(haPlatform.matterbridgeDevices.get(lightCtEntity.entity_id)?.getAttribute(LevelControl.Cluster.id, 'currentLevel')).toBe(100); // brightness 150 -> ~149
+    expect(haPlatform.matterbridgeDevices.get(lightCtEntity.entity_id)?.getAttribute(ColorControl.Cluster.id, 'colorTemperatureMireds')).toBe(500);
+    expect(haPlatform.matterbridgeDevices.get(lockEntity.entity_id)?.getAttribute(DoorLock.Cluster.id, 'lockState')).toBe(DoorLock.LockState.Locked);
+    expect(haPlatform.matterbridgeDevices.get(valveEntity.entity_id)?.getAttribute(ValveConfigurationAndControl.Cluster.id, 'currentState')).toBe(
+      ValveConfigurationAndControl.ValveState.Open,
+    );
+    expect(haPlatform.matterbridgeDevices.get(valveEntity.entity_id)?.getAttribute(ValveConfigurationAndControl.Cluster.id, 'currentLevel')).toBe(50);
+    expect(haPlatform.matterbridgeDevices.get(vacuumEntity.entity_id)?.getAttribute(RvcRunMode.Cluster.id, 'currentMode')).toBe(1); // idle/docked
+    expect(haPlatform.matterbridgeDevices.get(vacuumEntity.entity_id)?.getAttribute(RvcOperationalState.Cluster.id, 'operationalState')).toBe(
+      RvcOperationalState.OperationalState.Docked,
+    );
+    expect(haPlatform.matterbridgeDevices.get(fanEntity.entity_id)?.getAttribute(FanControl.Cluster.id, 'fanMode')).toBe(FanControl.FanMode.Auto);
+    expect(haPlatform.matterbridgeDevices.get(fanEntity.entity_id)?.getAttribute(FanControl.Cluster.id, 'percentCurrent')).toBe(50);
+    expect(haPlatform.matterbridgeDevices.get(fanCompleteEntity.entity_id)?.getAttribute(FanControl.Cluster.id, 'fanMode')).toBe(FanControl.FanMode.Auto);
+    expect(haPlatform.matterbridgeDevices.get(fanCompleteEntity.entity_id)?.getAttribute(FanControl.Cluster.id, 'percentCurrent')).toBe(50);
+    expect(haPlatform.matterbridgeDevices.get(fanCompleteEntity.entity_id)?.getAttribute(FanControl.Cluster.id, 'airflowDirection')).toBe(FanControl.AirflowDirection.Forward);
+    expect(haPlatform.matterbridgeDevices.get(fanCompleteEntity.entity_id)?.getAttribute(FanControl.Cluster.id, 'rockSetting')).toEqual({
+      rockLeftRight: false,
+      rockRound: true,
+      rockUpDown: false,
+    });
+    expect(haPlatform.matterbridgeDevices.get(climateEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'systemMode')).toBe(Thermostat.SystemMode.Auto);
+    expect(haPlatform.matterbridgeDevices.get(climateEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'occupiedHeatingSetpoint')).toBe(2000);
+    expect(haPlatform.matterbridgeDevices.get(climateEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'occupiedCoolingSetpoint')).toBe(2400);
+    expect(haPlatform.matterbridgeDevices.get(climateEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'localTemperature')).toBe(2200);
+    expect(haPlatform.matterbridgeDevices.get(climateHeatEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'systemMode')).toBe(Thermostat.SystemMode.Heat);
+    expect(haPlatform.matterbridgeDevices.get(climateHeatEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'occupiedHeatingSetpoint')).toBe(2000);
+    expect(haPlatform.matterbridgeDevices.get(climateHeatEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'localTemperature')).toBe(2200);
+    expect(haPlatform.matterbridgeDevices.get(climateCoolEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'systemMode')).toBe(Thermostat.SystemMode.Cool);
+    expect(haPlatform.matterbridgeDevices.get(climateCoolEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'occupiedCoolingSetpoint')).toBe(2000);
+    expect(haPlatform.matterbridgeDevices.get(climateCoolEntity.entity_id)?.getAttribute(Thermostat.Cluster.id, 'localTemperature')).toBe(1800);
 
     // Clean the test environment
     await cleanup();
@@ -3596,3 +3254,604 @@ describe('Matterbridge ' + NAME, () => {
     await new Promise((resolve) => setTimeout(resolve, 500)); // Wait for async operations in matter.js to complete and helpers timeout
   });
 });
+
+// binary_sensor
+const batteryLowEntity = {
+  device_id: null,
+  entity_id: 'binary_sensor.battery_low',
+  id: 'battery-low-entity-id',
+  name: 'Battery Low Sensor',
+} as unknown as HassEntity;
+const batteryLowState = {
+  entity_id: batteryLowEntity.entity_id,
+  state: 'on', // 'on' = battery low, 'off' = battery okay
+  attributes: { device_class: 'battery', friendly_name: batteryLowEntity.name },
+} as unknown as HassState;
+
+const contactEntity = {
+  device_id: null,
+  entity_id: 'binary_sensor.door_contact',
+  id: '0b25a337cb83edefb1d310450ad2b0ac',
+  name: 'Single Entity Contact Sensor',
+} as unknown as HassEntity;
+const contactState = {
+  entity_id: contactEntity.entity_id,
+  state: 'on', // 'on' for open, 'off' for closed
+  attributes: { device_class: 'door', friendly_name: contactEntity.name },
+} as unknown as HassState;
+
+const windowEntity = {
+  device_id: null,
+  entity_id: 'binary_sensor.window_contact',
+  id: 'window-entity-id',
+  name: 'Window Contact Sensor',
+} as unknown as HassEntity;
+const windowState = {
+  entity_id: windowEntity.entity_id,
+  state: 'on', // 'on' = open, 'off' = closed
+  attributes: { device_class: 'window', friendly_name: windowEntity.name },
+} as unknown as HassState;
+
+const garageDoorEntity = {
+  device_id: null,
+  entity_id: 'binary_sensor.garage_door_contact',
+  id: 'garage-door-entity-id',
+  name: 'Garage Door Sensor',
+} as unknown as HassEntity;
+const garageDoorState = {
+  entity_id: garageDoorEntity.entity_id,
+  state: 'off', // 'on' = open, 'off' = closed
+  attributes: { device_class: 'garage_door', friendly_name: garageDoorEntity.name },
+} as unknown as HassState;
+
+const vibrationEntity = {
+  device_id: null,
+  entity_id: 'binary_sensor.vibration_sensor',
+  id: 'vibration-entity-id',
+  name: 'Vibration Sensor',
+} as unknown as HassEntity;
+const vibrationState = {
+  entity_id: vibrationEntity.entity_id,
+  state: 'off', // 'on' = vibration detected
+  attributes: { device_class: 'vibration', friendly_name: vibrationEntity.name },
+} as unknown as HassState;
+
+const coldEntity = {
+  device_id: null,
+  entity_id: 'binary_sensor.cold_sensor',
+  id: 'cold-entity-id',
+  name: 'Cold Sensor',
+} as unknown as HassEntity;
+const coldState = {
+  entity_id: coldEntity.entity_id,
+  state: 'off', // 'on' = cold condition
+  attributes: { device_class: 'cold', friendly_name: coldEntity.name },
+} as unknown as HassState;
+
+const moistureEntity = {
+  device_id: null,
+  entity_id: 'binary_sensor.moisture_sensor',
+  id: 'moisture-entity-id',
+  name: 'Moisture Sensor',
+} as unknown as HassEntity;
+const moistureState = {
+  entity_id: moistureEntity.entity_id,
+  state: 'off', // 'on' = moisture/leak detected
+  attributes: { device_class: 'moisture', friendly_name: moistureEntity.name },
+} as unknown as HassState;
+
+const occupancyEntity = {
+  device_id: null,
+  entity_id: 'binary_sensor.occupancy_sensor',
+  id: 'occupancy-entity-id',
+  name: 'Occupancy Sensor',
+} as unknown as HassEntity;
+const occupancyState = {
+  entity_id: occupancyEntity.entity_id,
+  state: 'off', // 'on' = occupied
+  attributes: { device_class: 'occupancy', friendly_name: occupancyEntity.name },
+} as unknown as HassState;
+
+const motionEntity = {
+  device_id: null,
+  entity_id: 'binary_sensor.motion_sensor',
+  id: 'motion-entity-id',
+  name: 'Motion Sensor',
+} as unknown as HassEntity;
+const motionState = {
+  entity_id: motionEntity.entity_id,
+  state: 'off', // 'on' = motion detected
+  attributes: { device_class: 'motion', friendly_name: motionEntity.name },
+} as unknown as HassState;
+
+const presenceEntity = {
+  device_id: null,
+  entity_id: 'binary_sensor.presence_sensor',
+  id: 'presence-entity-id',
+  name: 'Presence Sensor',
+} as unknown as HassEntity;
+const presenceStateMulti = {
+  entity_id: presenceEntity.entity_id,
+  state: 'off', // 'on' = presence detected
+  attributes: { device_class: 'presence', friendly_name: presenceEntity.name },
+} as unknown as HassState;
+
+const smokeEntity = {
+  device_id: null,
+  entity_id: 'binary_sensor.smoke_alarm',
+  id: 'smoke-entity-id',
+  name: 'Smoke Alarm',
+} as unknown as HassEntity;
+const smokeStateMulti = {
+  entity_id: smokeEntity.entity_id,
+  state: 'off', // 'on' = smoke detected
+  attributes: { device_class: 'smoke', friendly_name: smokeEntity.name },
+} as unknown as HassState;
+
+const coEntity = {
+  device_id: null,
+  entity_id: 'binary_sensor.co_alarm',
+  id: 'co-entity-id',
+  name: 'CO Alarm',
+} as unknown as HassEntity;
+const coStateMulti = {
+  entity_id: coEntity.entity_id,
+  state: 'off', // 'on' = CO detected
+  attributes: { device_class: 'carbon_monoxide', friendly_name: coEntity.name },
+} as unknown as HassState;
+
+// sensor
+const batteryLevelEntity = {
+  device_id: null,
+  entity_id: 'sensor.battery_level',
+  id: 'battery-level-entity-id',
+  name: 'Battery Level Sensor',
+} as unknown as HassEntity;
+const batteryLevelState = {
+  entity_id: batteryLevelEntity.entity_id,
+  state: '85',
+  attributes: { state_class: 'measurement', device_class: 'battery', unit_of_measurement: '%', friendly_name: batteryLevelEntity.name },
+} as unknown as HassState;
+
+const batteryVoltageEntity = {
+  device_id: null,
+  entity_id: 'sensor.battery_voltage',
+  id: 'battery-voltage-entity-id',
+  name: 'Battery Voltage Sensor',
+} as unknown as HassEntity;
+const batteryVoltageState = {
+  entity_id: batteryVoltageEntity.entity_id,
+  state: '3.7',
+  attributes: { state_class: 'measurement', device_class: 'voltage', unit_of_measurement: 'V', friendly_name: batteryVoltageEntity.name },
+} as unknown as HassState;
+
+const temperatureEntity = {
+  device_id: null,
+  entity_id: 'sensor.temperature',
+  id: 'temperature-entity-id',
+  name: 'Temperature Sensor',
+} as unknown as HassEntity;
+const temperatureState = {
+  entity_id: temperatureEntity.entity_id,
+  state: '22.6',
+  attributes: { state_class: 'measurement', device_class: 'temperature', unit_of_measurement: '°C', friendly_name: temperatureEntity.name },
+} as unknown as HassState;
+
+const humidityEntity = {
+  device_id: null,
+  entity_id: 'sensor.humidity',
+  id: 'humidity-entity-id',
+  name: 'Humidity Sensor',
+} as unknown as HassEntity;
+const humidityState = {
+  entity_id: humidityEntity.entity_id,
+  state: '56.3',
+  attributes: { state_class: 'measurement', device_class: 'humidity', unit_of_measurement: '%', friendly_name: humidityEntity.name },
+} as unknown as HassState;
+
+const pressureEntity = {
+  device_id: null,
+  entity_id: 'sensor.pressure',
+  id: 'pressure-entity-id',
+  name: 'Pressure Sensor',
+} as unknown as HassEntity;
+const pressureState = {
+  entity_id: pressureEntity.entity_id,
+  state: '1013',
+  attributes: { state_class: 'measurement', device_class: 'pressure', unit_of_measurement: 'hPa', friendly_name: pressureEntity.name },
+} as unknown as HassState;
+
+const atmosphericPressureEntity = {
+  device_id: null,
+  entity_id: 'sensor.atmospheric_pressure',
+  id: 'atmospheric-pressure-entity-id',
+  name: 'Atmospheric Pressure Sensor',
+} as unknown as HassEntity;
+const atmosphericPressureState = {
+  entity_id: atmosphericPressureEntity.entity_id,
+  state: '1013',
+  attributes: { state_class: 'measurement', device_class: 'atmospheric_pressure', unit_of_measurement: 'hPa', friendly_name: atmosphericPressureEntity.name },
+} as unknown as HassState;
+
+const illuminanceEntity = {
+  device_id: null,
+  entity_id: 'sensor.illuminance',
+  id: 'illuminance-entity-id',
+  name: 'Illuminance Sensor',
+} as unknown as HassEntity;
+const illuminanceState = {
+  entity_id: illuminanceEntity.entity_id,
+  state: '500',
+  attributes: { state_class: 'measurement', device_class: 'illuminance', unit_of_measurement: 'lx', friendly_name: illuminanceEntity.name },
+} as unknown as HassState;
+
+const energyEntity = {
+  device_id: null,
+  entity_id: 'sensor.energy',
+  id: 'energy-entity-id',
+  name: 'Energy Sensor',
+} as unknown as HassEntity;
+const energyState = {
+  entity_id: energyEntity.entity_id,
+  state: '12.34',
+  attributes: { state_class: 'total_increasing', device_class: 'energy', unit_of_measurement: 'kWh', friendly_name: energyEntity.name },
+} as unknown as HassState;
+
+const powerEntity = {
+  device_id: null,
+  entity_id: 'sensor.power',
+  id: 'power-entity-id',
+  name: 'Power Sensor',
+} as unknown as HassEntity;
+const powerState = {
+  entity_id: powerEntity.entity_id,
+  state: '100',
+  attributes: { state_class: 'measurement', device_class: 'power', unit_of_measurement: 'W', friendly_name: powerEntity.name },
+} as unknown as HassState;
+
+const currentEntity = {
+  device_id: null,
+  entity_id: 'sensor.current',
+  id: 'current-entity-id',
+  name: 'Current Sensor',
+} as unknown as HassEntity;
+const currentState = {
+  entity_id: currentEntity.entity_id,
+  state: '0.5',
+  attributes: { state_class: 'measurement', device_class: 'current', unit_of_measurement: 'A', friendly_name: currentEntity.name },
+} as unknown as HassState;
+
+const voltageEntity = {
+  device_id: null,
+  entity_id: 'sensor.voltage',
+  id: 'voltage-entity-id',
+  name: 'Voltage Sensor',
+} as unknown as HassEntity;
+const voltageState = {
+  entity_id: voltageEntity.entity_id,
+  state: '230',
+  attributes: { state_class: 'measurement', device_class: 'voltage', unit_of_measurement: 'V', friendly_name: voltageEntity.name },
+} as unknown as HassState;
+
+const aqiEntity = {
+  device_id: null,
+  entity_id: 'sensor.air_quality',
+  id: 'aqi-entity-id',
+  name: 'Air Quality Sensor',
+} as unknown as HassEntity;
+const aqiState = {
+  entity_id: aqiEntity.entity_id,
+  state: 'fair',
+  attributes: { state_class: 'measurement', device_class: 'aqi', friendly_name: aqiEntity.name },
+} as unknown as HassState;
+
+const vocEntity = {
+  device_id: null,
+  entity_id: 'sensor.volatile_organic_compounds',
+  id: 'voc-entity-id',
+  name: 'VOC Sensor',
+} as unknown as HassEntity;
+const vocState = {
+  entity_id: vocEntity.entity_id,
+  state: '100',
+  attributes: { state_class: 'measurement', device_class: 'volatile_organic_compounds', friendly_name: vocEntity.name },
+} as unknown as HassState;
+
+const vocPartsEntity = {
+  device_id: null,
+  entity_id: 'sensor.volatile_organic_compounds_parts',
+  id: 'voc-parts-entity-id',
+  name: 'VOC Parts Sensor',
+} as unknown as HassEntity;
+const vocPartsState = {
+  entity_id: vocPartsEntity.entity_id,
+  state: '150',
+  attributes: { state_class: 'measurement', device_class: 'volatile_organic_compounds_parts', friendly_name: vocPartsEntity.name },
+} as unknown as HassState;
+
+const co2Entity = {
+  device_id: null,
+  entity_id: 'sensor.carbon_dioxide',
+  id: 'co2-sensor-entity-id',
+  name: 'CO2 Sensor',
+} as unknown as HassEntity;
+const co2State = {
+  entity_id: co2Entity.entity_id,
+  state: '600',
+  attributes: { state_class: 'measurement', device_class: 'carbon_dioxide', friendly_name: co2Entity.name },
+} as unknown as HassState;
+
+const coSensorEntity = {
+  device_id: null,
+  entity_id: 'sensor.carbon_monoxide',
+  id: 'co-sensor-entity-id',
+  name: 'CO Sensor',
+} as unknown as HassEntity;
+const coSensorState = {
+  entity_id: coSensorEntity.entity_id,
+  state: '30',
+  attributes: { state_class: 'measurement', device_class: 'carbon_monoxide', friendly_name: coSensorEntity.name },
+} as unknown as HassState;
+
+const no2Entity = {
+  device_id: null,
+  entity_id: 'sensor.nitrogen_dioxide',
+  id: 'no2-entity-id',
+  name: 'NO2 Sensor',
+} as unknown as HassEntity;
+const no2State = {
+  entity_id: no2Entity.entity_id,
+  state: '15',
+  attributes: { state_class: 'measurement', device_class: 'nitrogen_dioxide', friendly_name: no2Entity.name },
+} as unknown as HassState;
+
+const ozoneEntity = {
+  device_id: null,
+  entity_id: 'sensor.ozone',
+  id: 'ozone-entity-id',
+  name: 'Ozone Sensor',
+} as unknown as HassEntity;
+const ozoneState = {
+  entity_id: ozoneEntity.entity_id,
+  state: '5',
+  attributes: { state_class: 'measurement', device_class: 'ozone', friendly_name: ozoneEntity.name },
+} as unknown as HassState;
+
+const formaldehydeEntity = {
+  device_id: null,
+  entity_id: 'sensor.formaldehyde',
+  id: 'formaldehyde-entity-id',
+  name: 'Formaldehyde Sensor',
+} as unknown as HassEntity;
+const formaldehydeState = {
+  entity_id: formaldehydeEntity.entity_id,
+  state: '2',
+  attributes: { state_class: 'measurement', device_class: 'formaldehyde', friendly_name: formaldehydeEntity.name },
+} as unknown as HassState;
+
+const radonEntity = {
+  device_id: null,
+  entity_id: 'sensor.radon',
+  id: 'radon-entity-id',
+  name: 'Radon Sensor',
+} as unknown as HassEntity;
+const radonState = {
+  entity_id: radonEntity.entity_id,
+  state: '50',
+  attributes: { state_class: 'measurement', device_class: 'radon', friendly_name: radonEntity.name },
+} as unknown as HassState;
+
+const pm1Entity = {
+  device_id: null,
+  entity_id: 'sensor.pm1',
+  id: 'pm1-entity-id',
+  name: 'PM1 Sensor',
+} as unknown as HassEntity;
+const pm1State = {
+  entity_id: pm1Entity.entity_id,
+  state: '5',
+  attributes: { state_class: 'measurement', device_class: 'pm1', friendly_name: pm1Entity.name },
+} as unknown as HassState;
+
+const pm25Entity = {
+  device_id: null,
+  entity_id: 'sensor.pm25',
+  id: 'pm25-entity-id',
+  name: 'PM2.5 Sensor',
+} as unknown as HassEntity;
+const pm25State = {
+  entity_id: pm25Entity.entity_id,
+  state: '12',
+  attributes: { state_class: 'measurement', device_class: 'pm25', friendly_name: pm25Entity.name },
+} as unknown as HassState;
+
+const pm10Entity = {
+  device_id: null,
+  entity_id: 'sensor.pm10',
+  id: 'pm10-entity-id',
+  name: 'PM10 Sensor',
+} as unknown as HassEntity;
+const pm10State = {
+  entity_id: pm10Entity.entity_id,
+  state: '20',
+  attributes: { state_class: 'measurement', device_class: 'pm10', friendly_name: pm10Entity.name },
+} as unknown as HassState;
+
+// control
+const switchEntity = {
+  device_id: null,
+  entity_id: 'switch.switch',
+  id: '0b25a337cb83edefb1d310450ad2b0ac',
+  name: 'Single Entity Switch',
+} as unknown as HassEntity;
+const switchState = {
+  entity_id: switchEntity.entity_id,
+  state: 'on',
+  attributes: { friendly_name: switchEntity.name },
+} as unknown as HassState;
+
+const lightOnOffEntity = {
+  device_id: null,
+  entity_id: 'light.light_onoff',
+  id: 'light-entity-id',
+  name: 'Single Entity Light OnOff',
+} as unknown as HassEntity;
+const lightOnOffState = {
+  entity_id: lightOnOffEntity.entity_id,
+  state: 'on',
+  attributes: { friendly_name: lightOnOffEntity.name },
+} as unknown as HassState;
+
+const lightDimmerEntity = {
+  device_id: null,
+  entity_id: 'light.light_dimmer',
+  id: 'light-entity-id',
+  name: 'Single Entity Light Dimmer',
+} as unknown as HassEntity;
+const lightDimmerState = {
+  entity_id: lightDimmerEntity.entity_id,
+  state: 'on',
+  attributes: { friendly_name: lightDimmerEntity.name, brightness: 150 },
+} as unknown as HassState;
+
+const lightCtEntity = {
+  device_id: null,
+  entity_id: 'light.light_ct',
+  id: 'light-entity-id',
+  name: 'Single Entity Light CT',
+} as unknown as HassEntity;
+const lightCtState = {
+  entity_id: lightCtEntity.entity_id,
+  state: 'on',
+  attributes: { friendly_name: lightCtEntity.name, brightness: 100, color_temp: 500, supported_color_modes: ['color_temp'], color_mode: 'color_temp' },
+} as unknown as HassState;
+
+// lock
+const lockEntity = {
+  device_id: null,
+  entity_id: 'lock.lock',
+  id: 'lock-entity-id',
+  name: 'Single Entity Lock',
+} as unknown as HassEntity;
+const lockState = {
+  entity_id: lockEntity.entity_id,
+  state: 'locked',
+  attributes: { friendly_name: lockEntity.name },
+} as unknown as HassState;
+
+// valve
+const valveEntity = {
+  device_id: null,
+  entity_id: 'valve.valve',
+  id: 'valve-entity-id',
+  name: 'Single Entity Valve',
+} as unknown as HassEntity;
+const valveState = {
+  entity_id: valveEntity.entity_id,
+  state: 'open',
+  attributes: { friendly_name: valveEntity.name, current_position: 50 },
+} as unknown as HassState;
+
+// vacuum
+const vacuumEntity = {
+  device_id: null,
+  entity_id: 'vacuum.vacuum',
+  id: 'vacuum-entity-id',
+  name: 'Single Entity Vacuum',
+} as unknown as HassEntity;
+const vacuumState = {
+  entity_id: vacuumEntity.entity_id,
+  state: 'docked',
+  attributes: { friendly_name: vacuumEntity.name },
+} as unknown as HassState;
+
+// fan
+const fanEntity = {
+  device_id: null,
+  entity_id: 'fan.fan',
+  id: 'fan-entity-id',
+  name: 'Single Entity Fan',
+} as unknown as HassEntity;
+const fanState = {
+  entity_id: fanEntity.entity_id,
+  state: 'on',
+  attributes: { friendly_name: fanEntity.name, percentage: 50, preset_modes: ['auto', 'low', 'medium', 'high'], preset_mode: 'auto' },
+} as unknown as HassState;
+
+const fanCompleteEntity = {
+  device_id: null,
+  entity_id: 'fan.fan_complete',
+  id: 'fan-complete-entity-id',
+  name: 'Single Entity Fan Complete',
+} as unknown as HassEntity;
+const fanCompleteState = {
+  entity_id: fanCompleteEntity.entity_id,
+  state: 'on',
+  attributes: {
+    friendly_name: fanCompleteEntity.name,
+    percentage: 50,
+    preset_modes: ['auto', 'low', 'medium', 'high'],
+    preset_mode: 'auto',
+    direction: 'forward',
+    oscillate: true,
+  },
+} as unknown as HassState;
+
+// climate
+const climateEntity = {
+  device_id: null,
+  entity_id: 'climate.climate_heat_cool',
+  id: 'climate-heat_cool-entity-id',
+  name: 'Single Entity Climate Heat Cool',
+} as unknown as HassEntity;
+const climateState = {
+  entity_id: climateEntity.entity_id,
+  state: 'heat_cool',
+  attributes: {
+    friendly_name: climateEntity.name,
+    hvac_modes: ['off', 'heat', 'cool', 'heat_cool'],
+    target_temp_low: 20,
+    target_temp_high: 24,
+    current_temperature: 22,
+    min_temp: 5,
+    max_temp: 35,
+  },
+} as unknown as HassState;
+
+const climateHeatEntity = {
+  device_id: null,
+  entity_id: 'climate.climate_heat',
+  id: 'climate-heat-entity-id',
+  name: 'Single Entity Climate Heat',
+} as unknown as HassEntity;
+const climateHeatState = {
+  entity_id: climateHeatEntity.entity_id,
+  state: 'heat',
+  attributes: {
+    friendly_name: climateHeatEntity.name,
+    hvac_modes: ['off', 'heat'],
+    temperature: 20,
+    current_temperature: 22,
+    min_temp: 5,
+    max_temp: 35,
+  },
+} as unknown as HassState;
+
+const climateCoolEntity = {
+  device_id: null,
+  entity_id: 'climate.climate_cool',
+  id: 'climate-cool-entity-id',
+  name: 'Single Entity Climate Cool',
+} as unknown as HassEntity;
+const climateCoolState = {
+  entity_id: climateCoolEntity.entity_id,
+  state: 'cool',
+  attributes: {
+    friendly_name: climateCoolEntity.name,
+    hvac_modes: ['off', 'cool'],
+    temperature: 20,
+    current_temperature: 18,
+    min_temp: 5,
+    max_temp: 35,
+  },
+} as unknown as HassState;

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -6,67 +6,18 @@ const HOMEDIR = path.join('jest', NAME);
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { rmSync } from 'node:fs';
 
 import { jest } from '@jest/globals';
-import { bridgedNode, colorTemperatureLight, dimmableOutlet, Matterbridge, MatterbridgeEndpoint, PlatformConfig } from 'matterbridge';
+import { bridgedNode, colorTemperatureLight, dimmableOutlet, Matterbridge, MatterbridgeEndpoint } from 'matterbridge';
 import { EndpointNumber } from 'matterbridge/matter/types';
 import { wait } from 'matterbridge/utils';
 import { AnsiLogger, db, dn, idn, LogLevel, nf, rs, CYAN, ign, wr, er, or, TimestampFormat } from 'matterbridge/logger';
 import { BooleanState, BridgedDeviceBasicInformation, FanControl, IlluminanceMeasurement, OccupancySensing, WindowCovering } from 'matterbridge/matter/clusters';
 
-import { HomeAssistantPlatform } from './platform.js';
+import { HomeAssistantPlatform, HomeAssistantPlatformConfig } from './platform.js';
 import { HassArea, HassConfig, HassDevice, HassEntity, HassLabel, HassServices, HassState, HomeAssistant } from './homeAssistant.js';
 import { MutableDevice } from './mutableDevice.js';
-import { flushAsync } from './jestHelpers.js';
-
-let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
-let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
-let consoleDebugSpy: jest.SpiedFunction<typeof console.log>;
-let consoleInfoSpy: jest.SpiedFunction<typeof console.log>;
-let consoleWarnSpy: jest.SpiedFunction<typeof console.log>;
-let consoleErrorSpy: jest.SpiedFunction<typeof console.log>;
-const debug = false; // Set to true to enable debug logging
-
-if (!debug) {
-  loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
-  consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {});
-  consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation((...args: any[]) => {});
-  consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation((...args: any[]) => {});
-  consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: any[]) => {});
-  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {});
-} else {
-  loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
-  consoleLogSpy = jest.spyOn(console, 'log');
-  consoleDebugSpy = jest.spyOn(console, 'debug');
-  consoleInfoSpy = jest.spyOn(console, 'info');
-  consoleWarnSpy = jest.spyOn(console, 'warn');
-  consoleErrorSpy = jest.spyOn(console, 'error');
-}
-
-function setDebug(debug: boolean) {
-  if (debug) {
-    loggerLogSpy.mockRestore();
-    consoleLogSpy.mockRestore();
-    consoleDebugSpy.mockRestore();
-    consoleInfoSpy.mockRestore();
-    consoleWarnSpy.mockRestore();
-    consoleErrorSpy.mockRestore();
-    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log');
-    consoleLogSpy = jest.spyOn(console, 'log');
-    consoleDebugSpy = jest.spyOn(console, 'debug');
-    consoleInfoSpy = jest.spyOn(console, 'info');
-    consoleWarnSpy = jest.spyOn(console, 'warn');
-    consoleErrorSpy = jest.spyOn(console, 'error');
-  } else {
-    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
-    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {});
-    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation((...args: any[]) => {});
-    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation((...args: any[]) => {});
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: any[]) => {});
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {});
-  }
-}
+import { flushAsync, setupTest, loggerLogSpy, createTestEnvironment } from './jestHelpers.js';
 
 const readMockHomeAssistantFile = () => {
   const filePath = path.join('mock', 'homeassistant.json');
@@ -87,8 +38,11 @@ const readMockHomeAssistantFile = () => {
   }
 };
 
-// Cleanup the test environment
-rmSync(HOMEDIR, { recursive: true, force: true });
+// Setup the test environment
+setupTest(NAME, false);
+
+// Cleanup the matter environment
+createTestEnvironment(HOMEDIR);
 
 describe('HassPlatform', () => {
   let haPlatform: HomeAssistantPlatform;
@@ -136,22 +90,28 @@ describe('HassPlatform', () => {
   const mockConfig = {
     name: 'matterbridge-hass',
     type: 'DynamicPlatform',
+    version: '1.0.0',
     host: 'http://homeassistant.local:8123',
     token: 'long-lived token',
-    certificatePath: undefined,
+    certificatePath: '',
     rejectUnauthorized: true,
     reconnectTimeout: 60,
     reconnectRetries: 10,
     filterByArea: '',
     filterByLabel: '',
+    applyFiltersToDeviceEntities: false,
     whiteList: [],
     blackList: [],
     entityBlackList: [],
     deviceEntityBlackList: {},
+    splitEntities: [],
+    namePostfix: '',
+    postfix: '',
+    airQualityRegex: '',
     enableServerRvc: false,
     debug: false,
     unregisterOnShutdown: false,
-  } as PlatformConfig;
+  } as HomeAssistantPlatformConfig;
 
   const mockData = readMockHomeAssistantFile();
   if (!mockData) {
@@ -207,19 +167,10 @@ describe('HassPlatform', () => {
       return Promise.resolve({} as any);
     });
 
-  beforeAll(() => {
-    // Spy on and mock the AnsiLogger.log method
-    loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {
-      // console.log(`Mocked log: ${level} - ${message}`, ...parameters);
-    });
-
-    // Spy on and mock console.log
-    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {
-      // console.error(`Mocked console.log: ${args}`);
-    });
-  });
+  beforeAll(() => {});
 
   beforeEach(() => {
+    // Clear all mocks
     jest.clearAllMocks();
     if (haPlatform) {
       haPlatform.haSubscriptionId = 1;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -52,6 +52,29 @@ import { addBinarySensorEntity } from './binary_sensor.entity.js';
 import { addSensorEntity } from './sensor.entity.js';
 import { addControlEntity } from './control.entity.js';
 
+export interface HomeAssistantPlatformConfig extends PlatformConfig {
+  host: string;
+  certificatePath: string;
+  rejectUnauthorized: boolean;
+  token: string;
+  reconnectTimeout: number;
+  reconnectRetries: number;
+  filterByArea: string;
+  filterByLabel: string;
+  applyFiltersToDeviceEntities: boolean;
+  whiteList: string[];
+  blackList: string[];
+  entityBlackList: string[];
+  deviceEntityBlackList: Record<string, string[]>;
+  splitEntities: string[];
+  namePostfix: string;
+  postfix: string;
+  airQualityRegex: string;
+  enableServerRvc: boolean;
+  debug: boolean;
+  unregisterOnShutdown: boolean;
+}
+
 /**
  * HomeAssistantPlatform class extends the MatterbridgeDynamicPlatform class.
  * It initializes the Home Assistant connection, fetches data, subscribes to events,
@@ -91,7 +114,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
    * @param {AnsiLogger} log - The logger instance.
    * @param {PlatformConfig} config - The platform configuration.
    */
-  constructor(matterbridge: Matterbridge, log: AnsiLogger, config: PlatformConfig) {
+  constructor(matterbridge: Matterbridge, log: AnsiLogger, config: HomeAssistantPlatformConfig) {
     super(matterbridge, log, config);
 
     // Verify that Matterbridge is the correct version
@@ -690,6 +713,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
     this.matterbridgeDevices.clear();
     this.batteryVoltageEntities.clear();
     this.endpointNames.clear();
+    this.log.info(`Shut down platform ${idn}${this.config.name}${rs}${nf} completed`);
   }
 
   async commandHandler(

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -341,9 +341,13 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       if (this.supportedCoreDomains.includes(domain))
         addControlEntity(mutableDevice, entity, hassState, this.commandHandler.bind(this), this.subscribeHandler.bind(this), this.log);
       // Lookup and add sensor domain entity.
-      if (domain === 'sensor') addSensorEntity(mutableDevice, entity, hassState, this.airQualityRegex, false, this.log);
+      if (domain === 'sensor') addSensorEntity(mutableDevice, entity, hassState, this.airQualityRegex, name.includes('battery'), this.log);
       // Lookup and add binary_sensor domain entity.
       if (domain === 'binary_sensor') addBinarySensorEntity(mutableDevice, entity, hassState, this.log);
+      // Add PowerSource with battery feature if the entity is a battery
+      if (mutableDevice.get().deviceTypes.includes(powerSource)) {
+        mutableDevice.addClusterServerBatteryPowerSource('', PowerSource.BatChargeLevel.Ok, 200);
+      }
 
       if (entity.platform === 'template') {
         mutableDevice.setComposedType(`Hass Template`);


### PR DESCRIPTION
### Roadmap to release 1.0.0

- ✅ support all single entities reusing the same code of the device entities.
- ✅ add automatic 'merge' ability in MutableDevice: this will merge the entities that belongs to a single Matter device. Used for PowerSource, ElectricalSensor and AirQuality clusters.
- ✅ add automatic 'remap' ability in MutableDevice for single entities: this will remap to the main enpoint the not overlapping (the disambiguation matter rule) child endpoints from the single entity. Useful for Alexa users since Alexa is not able to deal with composed devices.
- ✅ add automatic 'remap' ability in MutableDevice for device entities: this will remap to the main enpoint the not overlapping (the disambiguation matter rule) child endpoints from the device. Useful for Alexa users since Alexa is not able to deal with composed devices.
- ✅ add automatic 'split' ability in MutableDevice: this will add the overlapping child endpoints from the device like a single new device with the Friendly name of the original entity. Useful for Alexa users since Alexa is not able to deal with composed devices. This should not be necessary but right now the taglist is not supported on any controller.
- ✅ add rock direction attributes to fan domain (https://github.com/Luligu/matterbridge-hass/issues/77)
- ✅ add vacuum domain. When pairing to Apple Home always enable enableServerRvc in the config.
- ✅ add valve domain (requested by Ludovic BOUÉ).
- ✅ add group helper (https://github.com/Luligu/matterbridge-hass/issues/75).
- add fan cluster to climate domain or use AirConditioner for climate (Tamer). On hold cause Google Home cannot show correctly the AirConditioner device type.
- add fan preset_mode converter for "Normal" and "Auto" and not standard preset_modes.
- add water heater domain (requested by Ludovic BOUÉ).
- add media_player domain (requested by Tamer).

### Naming issues explained

For the naming issues (expecially upsetting with Alexa) read the explanation and the solution [here](https://github.com/Luligu/matterbridge-hass/discussions/86).

## [0.4.1] - 2025-09-06

### Breaking changes

See also the breaking changes of the releases 0.4.0 and 0.3.0 please.

### Added

- [battery]: Added support for battery type individual and split entities (battery low, battery level and battery voltage).
- [select]: Added select to splitEntities. It is possibile to pick up from the list of entities.
- [readme]: Improved the readme.
- [jest]: Added an helper to make all tests standard and more efficient.
- [platform]: Typed HomeAssistantPlatformConfig.

### Changed

- [package]: Updated dependencies.

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="bmc-button.svg" alt="Buy me a coffee" width="80">
</a>
