### PR TITLE
Release 1.0.10

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -89,7 +89,9 @@ Dev containers have networking limitations depending on the host OS and Docker s
         "git.autofetch": true,
         "files.eol": "\n",
         "files.insertFinalNewline": true,
-        "files.trimFinalNewlines": true
+        "files.trimFinalNewlines": true,
+        "js/ts.tsdk.path": "node_modules/typescript/lib",
+        "js/ts.tsdk.promptToUseWorkspaceVersion": false
       }
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ If you like this project and find it useful, please consider giving it a **star*
 
 - [logger]: Fix the maximum mireds value. Thanks jvmahon (https://github.com/Luligu/matterbridge/issues/523).
 - [split]: Fix the name priority for split entities.
+- [filter]: Ignore area for device entities and split entities.
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ If you like this project and find it useful, please consider giving it a **star*
 
 > For naming issues (especially upsetting with Alexa), read the explanation and the solution [here](https://github.com/Luligu/matterbridge-hass/discussions/86).
 
+## [1.0.10] - Dev branch
+
+### Changed
+
+- [package]: Update dependencies.
+- [package]: Bump package to `automator` v.3.1.2.
+- [package]: Bump `eslint` to v.10.0.3.
+
+### Fixed
+
+- [logger]: Fix mireds max value. Thanks jvmahon (https://github.com/Luligu/matterbridge/issues/523).
+
+<a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
+
 ## [1.0.9] - 2026-03-06
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ If you like this project and find it useful, please consider giving it a **star*
 
 ## [1.0.10] - Dev branch
 
+### Breaking Changes
+
+- [split]: The names of split entities may now be chosen using this logic:
+  - `Friendly name` => `Name` => `Original name` (i.e. Computer Plug Child Lock). This avoids most duplicate-name issues, but the name will probably be truncated to 32 characters.
+  - `Name` => `Original name` => `Friendly name` (i.e. Child Lock). This will probably create duplicate-name issues unless you change the name.
+
+  If you change this option, check the whiteList and blackList if you use them.
+
+### Added
+
+- [report]: A new file `report.log` is generated in the `Matterbridge/matterbridge-hass` directory. It contains the list of devices and entities, highlighting whether they are in filterByArea, have filterByLabel, or are in splitEntities.
+- [config]: Add the `splitNameStrategy` config option to select the naming strategy for split entities: `Entity name` (i.e. Child Lock) or `Friendly name` (i.e. Computer Plug Child Lock).
+
 ### Changed
 
 - [package]: Update dependencies.
@@ -24,7 +37,8 @@ If you like this project and find it useful, please consider giving it a **star*
 
 ### Fixed
 
-- [logger]: Fix mireds max value. Thanks jvmahon (https://github.com/Luligu/matterbridge/issues/523).
+- [logger]: Fix the maximum mireds value. Thanks jvmahon (https://github.com/Luligu/matterbridge/issues/523).
+- [split]: Fix the name priority for split entities.
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ If you like this project and find it useful, please consider giving it a **star*
 
 > For naming issues (especially upsetting with Alexa), read the explanation and the solution [here](https://github.com/Luligu/matterbridge-hass/discussions/86).
 
-## [1.0.10] - Dev branch
+## [1.0.10] - 2026-03-09
 
 ### Breaking Changes
 
@@ -37,7 +37,7 @@ If you like this project and find it useful, please consider giving it a **star*
 
 ### Fixed
 
-- [logger]: Fix the maximum mireds value. Thanks jvmahon (https://github.com/Luligu/matterbridge/issues/523).
+- [mireds]: Fix the maximum mireds value. Thanks jvmahon (https://github.com/Luligu/matterbridge/issues/523).
 - [split]: Fix the name priority for split entities.
 - [filter]: Ignore area for device entities and split entities.
 

--- a/matterbridge-hass.config.json
+++ b/matterbridge-hass.config.json
@@ -15,6 +15,7 @@
   "entityBlackList": [],
   "deviceEntityBlackList": {},
   "splitEntities": [],
+  "splitNameStrategy": "Entity name",
   "namePostfix": "",
   "postfix": "",
   "airQualityRegex": "",

--- a/matterbridge-hass.schema.json
+++ b/matterbridge-hass.schema.json
@@ -5,56 +5,67 @@
   "required": ["host", "token"],
   "properties": {
     "name": {
+      "title": "Name",
       "description": "Plugin name",
       "type": "string",
       "readOnly": true,
       "ui:widget": "hidden"
     },
     "type": {
+      "title": "Type",
       "description": "Plugin type",
       "type": "string",
       "readOnly": true,
       "ui:widget": "hidden"
     },
     "host": {
+      "title": "Host",
       "description": "Home Assistant host (eg. ws://homeassistant.local:8123 or ws://homeassistant:8123 or ws://<IP-ADDRESS>:8123). For ssl connections use wss:// (eg. wss://homeassistant.local:8123) and enable rejectUnauthorized or provide certificatePath.",
       "type": "string",
       "default": "ws://homeassistant.local:8123"
     },
     "certificatePath": {
+      "title": "CA Certificate Path",
       "description": "Fully qualified path to the SSL ca certificate file. This is only needed if you use a self-signed certificate and rejectUnauthorized is enabled.",
       "type": "string"
     },
     "rejectUnauthorized": {
+      "title": "Reject Unauthorized",
       "description": "Ignore SSL certificate errors. It allows to connect to Home Assistant with self-signed certificates.",
       "type": "boolean",
       "default": false
     },
     "token": {
+      "title": "Token",
       "description": "Home Assistant Long-Lived Access Token",
       "type": "string"
     },
     "reconnectTimeout": {
+      "title": "Reconnect Timeout",
       "description": "Reconnect timeout in seconds (minimum 30 seconds). If the connection is lost, the plugin will try to reconnect after this timeout.",
       "type": "number",
       "default": 60
     },
     "reconnectRetries": {
+      "title": "Reconnect Retries",
       "description": "Number of times to try to reconnect before giving up. Set to 0 for no reconnects.",
       "type": "number",
       "default": 10
     },
     "filterByArea": {
+      "title": "Filter By Area",
       "description": "Filter devices and individual entities by area (use area name). If enabled, only devices and individual entities in the selected area will be exposed. If disabled, all devices and individual entities will be exposed.",
       "type": "string",
       "default": ""
     },
     "filterByLabel": {
-      "description": "Filter devices and individual entities by label (use label name). If enabled, only devices and individual entities with the selected label will be exposed. If disabled, all devices and individual entities will be exposed.",
+      "title": "Filter By Label",
+      "description": "Filter devices and individual entities by label (use label name). If enabled, only devices, device entities and individual entities with the selected label will be exposed. If disabled, all devices, device entities and individual entities will be exposed.",
       "type": "string",
       "default": ""
     },
     "whiteList": {
+      "title": "Whitelist",
       "description": "Only the devices, individual entities and split entities in the list will be exposed. Use the name or the id. If the list is empty, all the devices, individual entities and split entities will be exposed.",
       "type": "array",
       "items": {
@@ -64,6 +75,7 @@
       "selectFrom": "name"
     },
     "blackList": {
+      "title": "Blacklist",
       "description": "The devices, individual entities and split entities in the list will not be exposed. Use the name or the id. If the list is empty, no devices, individual entities and split entities will be excluded.",
       "type": "array",
       "items": {
@@ -73,6 +85,7 @@
       "selectFrom": "name"
     },
     "entityBlackList": {
+      "title": "Entity Blacklist",
       "description": "Not used in this plugin.",
       "type": "array",
       "items": {
@@ -83,6 +96,7 @@
       "ui:widget": "hidden"
     },
     "deviceEntityBlackList": {
+      "title": "Device Entity Blacklist",
       "description": "List of entities not to be exposed for a single device. Enter in the first field the name of the device and in the list add all the entity names you want to exclude for that device. This is only related to device entities, not individual entities or split entities.",
       "type": "object",
       "uniqueItems": true,
@@ -98,6 +112,7 @@
       }
     },
     "splitEntities": {
+      "title": "Split Entities",
       "description": "The device entities in the list will be exposed like an independent device and removed from their device. Enter the entity_id (i.e. switch.computer_plug_child_lock). Split entities must satisfy the filters (if any) and the whiteList (if any).",
       "type": "array",
       "items": {
@@ -106,31 +121,44 @@
       "uniqueItems": true,
       "selectEntityFrom": "description"
     },
+    "splitNameStrategy": {
+      "title": "Split Name Strategy",
+      "description": "Strategy used for split entity names. Entity name: use the entity name (i.e. Child Lock) if it exists, otherwise use the friendly name. Friendly name: use the friendly name (i.e. Computer Plug Child Lock) if it exists, otherwise use the entity name. You will lose the configuration of the devices in your controller when changing this value and you may need to pair again the controller.",
+      "type": "string",
+      "enum": ["Entity name", "Friendly name"],
+      "default": "Entity name"
+    },
     "namePostfix": {
-      "description": "Add this unique postfix (3 characters max) to each device name to avoid collision with other instances (you may loose the configuration of the devices in your controller when changing this value or you may need to pair again the controller).",
+      "title": "Name Postfix",
+      "description": "Add this unique postfix (3 characters max) to each device name to avoid collision with other instances (you will lose the configuration of the devices in your controller when changing this value and you may need to pair again the controller).",
       "type": "string",
       "default": ""
     },
     "postfix": {
-      "description": "Add this unique postfix (3 characters max) to each device serial to avoid collision with other instances (you may loose the configuration of the devices in your controller when changing this value or you may need to pair again the controller).",
+      "title": "Serial Postfix",
+      "description": "Add this unique postfix (3 characters max) to each device serial to avoid collision with other instances (you will lose the configuration of the devices in your controller when changing this value and you may need to pair again the controller).",
       "type": "string",
       "default": ""
     },
     "airQualityRegex": {
+      "title": "Air Quality Regex",
       "description": "Custom regex pattern to match not standard air quality sensors entities (e.g., '^sensor\\..*_air_quality$').",
       "type": "string"
     },
     "enableServerRvc": {
+      "title": "Enable Server Rvc",
       "description": "Enable the Robot Vacuum Cleaner in server mode (Apple Home will crash unless you use this mode!). Also blacklist any other entities related to the vacuum cleaner device to avoid Apple Home crashes.",
       "type": "boolean",
       "default": true
     },
     "debug": {
+      "title": "Debug",
       "description": "Enable the debug for the plugin (development only)",
       "type": "boolean",
       "default": false
     },
     "unregisterOnShutdown": {
+      "title": "Unregister On Shutdown",
       "description": "Unregister all devices on shutdown (development only)",
       "type": "boolean",
       "default": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge-hass",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-hass",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "node-ansi-logger": "3.2.0",
@@ -24,7 +24,7 @@
         "@vitest/coverage-v8": "4.0.18",
         "@vitest/eslint-plugin": "1.6.9",
         "cross-env": "10.1.0",
-        "eslint": "10.0.2",
+        "eslint": "10.0.3",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-jest": "29.15.0",
         "eslint-plugin-jsdoc": "62.7.1",
@@ -1115,37 +1115,37 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.2.tgz",
-      "integrity": "sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==",
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.2",
+        "@eslint/object-schema": "^3.0.3",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.1"
+        "minimatch": "^10.2.4"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
-      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.0"
+        "@eslint/core": "^1.1.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1244,9 +1244,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.2.tgz",
-      "integrity": "sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1254,13 +1254,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
-      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.0",
+        "@eslint/core": "^1.1.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -4088,18 +4088,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
-      "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
+      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.2",
+        "@eslint/config-array": "^0.23.3",
         "@eslint/config-helpers": "^0.5.2",
-        "@eslint/core": "^1.1.0",
-        "@eslint/plugin-kit": "^0.6.0",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -4108,7 +4108,7 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.1",
+        "eslint-scope": "^9.1.2",
         "eslint-visitor-keys": "^5.0.1",
         "espree": "^11.1.1",
         "esquery": "^1.7.0",
@@ -4121,7 +4121,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.1",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -4344,9 +4344,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.1.tgz",
-      "integrity": "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4389,9 +4389,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.1.tgz",
-      "integrity": "sha512-AVHPqQoZYc+RUM4/3Ly5udlZY/U4LS8pIG05jEjWM2lQMU/oaZ7qshzAl2YP1tfNmXfftH3ohurfwNAug+MnsQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4708,9 +4708,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.0.tgz",
+      "integrity": "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-hass",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Matterbridge hass plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",
@@ -75,7 +75,7 @@
     "test:watch": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" jest --maxWorkers=100% --watch",
     "test:verbose": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" jest --maxWorkers=100% --verbose",
     "test:coverage": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" jest --maxWorkers=100% --coverage --coverageThreshold=\"{ \\\"global\\\": { \\\"lines\\\": 100, \\\"functions\\\": 100 } }\"",
-    "test:debug": "node --no-warnings --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand",
+    "test:debug": "node --no-warnings --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:vitest": "vitest run",
     "test:vitest:watch": "vitest --reporter verbose",
     "test:vitest:verbose": "vitest run --reporter verbose",
@@ -132,7 +132,7 @@
     "@vitest/coverage-v8": "4.0.18",
     "@vitest/eslint-plugin": "1.6.9",
     "cross-env": "10.1.0",
-    "eslint": "10.0.2",
+    "eslint": "10.0.3",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-jest": "29.15.0",
     "eslint-plugin-jsdoc": "62.7.1",
@@ -150,7 +150,7 @@
     "vitest": "4.0.18"
   },
   "overrides": {
-    "eslint": "10.0.2",
+    "eslint": "10.0.3",
     "@eslint/js": "10.0.1"
   }
 }

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -134,9 +134,9 @@ export function miredsToKelvin(mired: number, round?: 'floor' | 'ceil'): number 
  * HomeAssistant uses always floor.
  */
 export function kelvinToMireds(kelvin: number, round?: 'floor' | 'ceil'): number {
-  if (round === 'floor') return Math.floor(1000000 / kelvin);
-  else if (round === 'ceil') return Math.ceil(1000000 / kelvin);
-  else return Math.round(1000000 / kelvin);
+  if (round === 'floor') return clamp(Math.floor(1000000 / kelvin), 1, 65279);
+  else if (round === 'ceil') return clamp(Math.ceil(1000000 / kelvin), 1, 65279);
+  else return clamp(Math.round(1000000 / kelvin), 1, 65279);
 }
 
 /**

--- a/src/module.matter.test.ts
+++ b/src/module.matter.test.ts
@@ -3101,6 +3101,27 @@ describe('Matterbridge ' + NAME, () => {
     expect(haPlatform.offUpdatedEntities.has(lightEntity.entity_id)).toBe(true); // The entity should be added to the offUpdatedEntities set because we received a command with executeIfOff true while the light was off
     haPlatform.offUpdatedEntities.clear();
 
+    /* 2bis) The light is off we send moveToColorTemperature 200 with executeIfOff true and no min max attributes */
+    jest.clearAllMocks();
+    lightState.attributes.min_color_temp_kelvin = null;
+    lightState.attributes.max_color_temp_kelvin = null;
+    haPlatform.ha.hassStates.set(lightState.entity_id, lightState);
+    await invokeBehaviorCommand(device, 'colorControl', 'moveToColorTemperature', getMoveToColorTemperatureRequest(200, 0, true));
+    expect(device.getAttribute(OnOff.Cluster.id, 'onOff')).toBe(false); // The state should remain off because executeIfOff is true
+    expect(device.getAttribute(LevelControl.Cluster.id, 'currentLevel')).toBe(200); // The level should not change
+    expect(device.getAttribute(ColorControl.Cluster.id, 'colorMode')).toBe(ColorControl.ColorMode.ColorTemperatureMireds); // The color mode should change to ColorTemperatureMireds because the command was moveToColorTemperature
+    expect(device.getAttribute(ColorControl.Cluster.id, 'colorTemperatureMireds')).toBe(200); // The color temperature should change because the light is off and executeIfOff is true
+    expect(device.getAttribute(ColorControl.Cluster.id, 'currentHue')).toBe(127);
+    expect(device.getAttribute(ColorControl.Cluster.id, 'currentSaturation')).toBe(127);
+    expect(device.getAttribute(ColorControl.Cluster.id, 'currentX')).toBe(0);
+    expect(device.getAttribute(ColorControl.Cluster.id, 'currentY')).toBe(0);
+    expect(callServiceSpy).not.toHaveBeenCalled(); // No service call should be made because the light is off
+    expect(haPlatform.offUpdatedEntities.has(lightEntity.entity_id)).toBe(true); // The entity should be added to the offUpdatedEntities set because we received a command with executeIfOff true while the light was off
+    haPlatform.offUpdatedEntities.clear();
+    lightState.attributes.min_color_temp_kelvin = 2500;
+    lightState.attributes.max_color_temp_kelvin = 6500;
+    haPlatform.ha.hassStates.set(lightState.entity_id, lightState);
+
     /* 3) The light is off we send moveToHue moveToSaturation moveToHueAndSaturation with executeIfOff true */
     jest.clearAllMocks();
     await invokeBehaviorCommand(device, 'colorControl', 'moveToHue', getMoveToHueRequest(120, 0, true));

--- a/src/module.matter.test.ts
+++ b/src/module.matter.test.ts
@@ -232,6 +232,7 @@ describe('Matterbridge ' + NAME, () => {
     entityBlackList: [],
     deviceEntityBlackList: {},
     splitEntities: [],
+    splitNameStrategy: 'Entity name',
     namePostfix: '',
     postfix: '',
     airQualityRegex: '',
@@ -3888,12 +3889,9 @@ describe('Matterbridge ' + NAME, () => {
     expect(addClusterServerBooleanStateSpy).toHaveBeenCalledWith(contactEntity.entity_id, false);
 
     // No warnings or errors
-    expect(loggerWarnSpy).not.toHaveBeenCalled();
+    expect(loggerWarnSpy).not.toHaveBeenCalledTimes(3); // 3 warnings for split entities should be called for individual entities
     expect(loggerErrorSpy).not.toHaveBeenCalled();
     expect(loggerFatalSpy).not.toHaveBeenCalled();
-    expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.WARN, expect.anything());
-    expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.ERROR, expect.anything());
-    expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.FATAL, expect.anything());
 
     // @ts-expect-error accessing private member for testing
     await haPlatform.checkEndpointNumbers();

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -897,9 +897,7 @@ describe('HassPlatform', () => {
     haPlatform.config.filterByArea = '';
     haPlatform.config.filterByLabel = 'Label 1';
 
-    await setDebug(true);
     await haPlatform.onStart();
-    await setDebug(false);
 
     expect(loggerInfoSpy).toHaveBeenCalledWith(`Starting platform ${idn}${mockConfig.name}${rs}${nf}: `);
     expect(loggerInfoSpy).toHaveBeenCalledWith(expect.stringContaining(`doesn't have the label`));

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -1079,6 +1079,37 @@ describe('HassPlatform', () => {
     await haPlatform.unregisterDevice(device);
   });
 
+  it('should not register an individual entity with the same name and friendly name', async () => {
+    expect(haPlatform).toBeDefined();
+
+    haPlatform.config.splitNameStrategy = 'Friendly name';
+    const entity = {
+      id: '0123456789abcdef',
+      entity_id: 'scene.turn_off_all_lights',
+      device_id: null,
+      disabled_by: null,
+      name: 'Turn off all lights',
+    } as unknown as HassEntity;
+    haPlatform.ha.hassEntities.set(entity.id, entity);
+    const state = {
+      state: 'off',
+      attributes: { friendly_name: 'Friendly Turn off all lights' },
+    } as HassState;
+    haPlatform.ha.hassStates.set(entity.entity_id, state);
+
+    expect(entity.name).toBeDefined();
+    if (!entity.name) return;
+    const device = new MatterbridgeEndpoint([onOffOutlet, bridgedNode], { id: 'test' }, true)
+      .createDefaultBridgedDeviceBasicInformationClusterServer(entity.name, entity.entity_id)
+      .addRequiredClusterServers();
+    await haPlatform.registerDevice(device);
+    await haPlatform.onStart('Test reason');
+
+    await haPlatform.unregisterDevice(device);
+
+    haPlatform.config.splitNameStrategy = 'Entity name';
+  });
+
   it('should register a Scene entity', async () => {
     expect(haPlatform).toBeDefined();
 

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -86,6 +86,7 @@ describe('HassPlatform', () => {
     entityBlackList: [],
     deviceEntityBlackList: {},
     splitEntities: [],
+    splitNameStrategy: 'Entity name',
     namePostfix: '',
     postfix: '',
     airQualityRegex: '',
@@ -372,10 +373,22 @@ describe('HassPlatform', () => {
     expect(haPlatform.isValidAreaLabel(null, ['foo'])).toBe(false);
   });
 
+  it('returns true if filterByArea is set and areaId is null and labelOnly is true', () => {
+    mockConfig.filterByArea = 'Living Room'; // area1 is Living Room
+    mockConfig.filterByLabel = '';
+    expect(haPlatform.isValidAreaLabel(null, ['foo'], true)).toBe(true);
+  });
+
   it('returns false if filterByArea is set and areaId does not match', () => {
     mockConfig.filterByArea = 'Living Room'; // area1 is Living Room
     mockConfig.filterByLabel = '';
     expect(haPlatform.isValidAreaLabel('area2', ['foo'])).toBe(false);
+  });
+
+  it('returns true if filterByArea is set and areaId does not match and labelOnly is true', () => {
+    mockConfig.filterByArea = 'Living Room'; // area1 is Living Room
+    mockConfig.filterByLabel = '';
+    expect(haPlatform.isValidAreaLabel('area2', ['foo'], true)).toBe(true);
   });
 
   it('returns false if filterByArea is set and areaId does not exist', () => {
@@ -1607,7 +1620,6 @@ describe('HassPlatform', () => {
       state: 'off', // 'on' for detected, 'off' for not detected
       attributes: {
         device_class: 'door',
-        friendly_name: 'Switch Contact Sensor',
       },
     } as unknown as HassState;
 
@@ -1766,7 +1778,7 @@ describe('HassPlatform', () => {
     haPlatform.ha.hassLabels.clear();
   });
 
-  it('should register a Switch split entity', async () => {
+  it('should register a Switch split entity with entity name', async () => {
     const device = {
       area_id: null,
       disabled_by: null,
@@ -1803,6 +1815,7 @@ describe('HassPlatform', () => {
     haPlatform.ha.hassStates.set(switchState.entity_id, switchState);
 
     haPlatform.config.splitEntities = [switchEntity.entity_id];
+    haPlatform.config.splitNameStrategy = 'Entity name';
 
     await haPlatform.onStart('Test reason');
 
@@ -1812,6 +1825,57 @@ describe('HassPlatform', () => {
     );
     expect(loggerDebugSpy).toHaveBeenCalledWith(`Registering device ${dn}${switchEntity.original_name}${db}...`);
     expect(matterbridge.addBridgedEndpoint).toHaveBeenCalled();
+  });
+
+  it('should register a Switch split entity with friendly name', async () => {
+    const device = {
+      area_id: null,
+      disabled_by: null,
+      entry_type: null,
+      id: 'd83398f83188759ed7329e97df00ee7c',
+      labels: [],
+      name: 'Switch with single entity',
+      name_by_user: null,
+    } as unknown as HassDevice;
+
+    const switchEntity = {
+      area_id: null,
+      device_id: 'd83398f83188759ed7329e97df00ee7c',
+      disabled_by: null,
+      entity_category: null,
+      entity_id: 'switch.single_entity',
+      has_entity_name: true,
+      id: '0b33a337cb83edefb1d310450ad2b0ac',
+      labels: [],
+      name: null,
+      original_name: 'Switch single entity',
+    } as unknown as HassEntity;
+
+    const switchState = {
+      entity_id: switchEntity.entity_id,
+      state: 'off',
+      attributes: {
+        friendly_name: 'Switch single entity friendly name',
+      },
+    } as unknown as HassState;
+
+    haPlatform.ha.hassDevices.set(device.id, device);
+    haPlatform.ha.hassEntities.set(switchEntity.entity_id, switchEntity);
+    haPlatform.ha.hassStates.set(switchState.entity_id, switchState);
+
+    haPlatform.config.splitEntities = [switchEntity.entity_id];
+    haPlatform.config.splitNameStrategy = 'Friendly name';
+
+    await haPlatform.onStart('Test reason');
+
+    expect(loggerInfoSpy).toHaveBeenCalledWith(`Starting platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      `Creating device for split entity ${idn}${switchState.attributes.friendly_name}${rs}${nf} domain ${CYAN}switch${nf} name ${CYAN}single_entity${nf}`,
+    );
+    expect(loggerDebugSpy).toHaveBeenCalledWith(`Registering device ${dn}${switchState.attributes.friendly_name}${db}...`);
+    expect(matterbridge.addBridgedEndpoint).toHaveBeenCalled();
+
+    haPlatform.config.splitNameStrategy = 'Entity name';
   });
 
   it('should not register a Switch split entity if blacklisted', async () => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -23,7 +23,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable jsdoc/reject-any-type */
 
-import fs from 'node:fs';
+import fs, { appendFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import {
@@ -78,6 +78,7 @@ export interface HomeAssistantPlatformConfig extends PlatformConfig {
   entityBlackList: string[];
   deviceEntityBlackList: Record<string, string[]>;
   splitEntities: string[];
+  splitNameStrategy: 'Entity name' | 'Friendly name';
   namePostfix: string;
   postfix: string;
   airQualityRegex: string;
@@ -195,6 +196,10 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       this.config.entityBlackList = isValidArray(this.config.entityBlackList, 1) ? this.config.entityBlackList : [];
       this.config.deviceEntityBlackList = isValidObject(this.config.deviceEntityBlackList, 1) ? this.config.deviceEntityBlackList : {};
       this.config.splitEntities = this.config.splitEntities === undefined ? [] : this.config.splitEntities;
+      this.config.splitNameStrategy =
+        isValidString(this.config.splitNameStrategy, 10) && ['Entity name', 'Friendly name'].includes(this.config.splitNameStrategy)
+          ? this.config.splitNameStrategy
+          : 'Entity name';
       this.config.namePostfix = isValidString(this.config.namePostfix, 1, 3) ? this.config.namePostfix : '';
       this.config.postfix = isValidString(this.config.postfix, 1, 3) ? this.config.postfix : '';
       this.config.airQualityRegex = isValidString(this.config.airQualityRegex, 1) ? this.config.airQualityRegex : '';
@@ -333,6 +338,48 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
     // Save devices, entities, states, config and services to a local file without awaiting
     this.savePayload(path.join(this.matterbridge.matterbridgePluginDirectory, 'matterbridge-hass', 'homeassistant.json'));
 
+    // Create a map of entity_id to device_id for quick lookup of the device of an entity
+    const areaId = this.ha.hassAreas.values().find((a) => a.name === this.config.filterByArea)?.area_id;
+    const labelId = this.ha.hassLabels.values().find((l) => l.name === this.config.filterByLabel)?.label_id;
+    const reportPath = path.join(this.matterbridge.matterbridgePluginDirectory, 'matterbridge-hass', 'report.log');
+    writeFileSync(reportPath, `Home Assistant Devices and Entities Report\n\n`); // Create or overwrite the report file
+    appendFileSync(reportPath, `Filter by area: ${this.config.filterByArea ? this.config.filterByArea + ' >>> ' + areaId : 'None'}\n\n`); // Create or overwrite the report file
+    appendFileSync(reportPath, `Filter by label: ${this.config.filterByLabel ? this.config.filterByLabel + ' >>> ' + labelId : 'None'}\n\n`); // Create or overwrite the report file
+    appendFileSync(reportPath, `Device Entities\n\n`);
+    for (const device of this.ha.hassDevices.values()) {
+      appendFileSync(
+        reportPath,
+        `Device: "${device.name_by_user ?? device.name}"` +
+          `${(device.name_by_user ?? device.name ?? '').length > 32 ? ' LONGNAME' : ''}` +
+          `${device.entry_type === 'service' ? ' SERVICE' : ''}` +
+          `${areaId && device.area_id === areaId ? ' AREA' : ''}` +
+          `${labelId && device.labels?.includes(labelId) ? ' LABEL' : ''}` +
+          `\n`,
+      );
+      for (const entity of this.ha.hassEntities.values().filter((e) => e.device_id === device.id)) {
+        const state = this.ha.hassStates.get(entity.entity_id);
+        appendFileSync(
+          reportPath,
+          `-  Entity: ${entity.entity_id} "${state?.attributes?.friendly_name}" - "${entity.name ?? entity.original_name}"` +
+            `${(state?.attributes?.friendly_name ?? entity.name ?? entity.original_name ?? '').length > 32 ? ' LONGNAME' : ''}` +
+            `${areaId && entity.area_id === areaId ? ' AREA' : ''}` + // Devices entities cannot be in a different area than their device.
+            `${labelId && entity.labels?.includes(labelId) ? ' LABEL' : ''}` +
+            `${this.config.splitEntities?.includes(entity.entity_id) ? ' SPLIT' : ''}\n`,
+        );
+      }
+    }
+    appendFileSync(reportPath, `\nIndividual Entities\n\n`);
+    for (const entity of this.ha.hassEntities.values().filter((e) => e.device_id === null)) {
+      const state = this.ha.hassStates.get(entity.entity_id);
+      appendFileSync(
+        reportPath,
+        `Individual Entity: ${entity.entity_id} "${state?.attributes?.friendly_name}" - "${entity.name ?? entity.original_name}"` +
+          `${(state?.attributes?.friendly_name ?? entity.name ?? entity.original_name ?? '').length > 32 ? ' LONGNAME' : ''}` +
+          `${areaId && entity.area_id === areaId ? ' AREA' : ''}` +
+          `${labelId && entity.labels?.includes(labelId) ? ' LABEL' : ''}\n`,
+      );
+    }
+
     // Clean the selectDevice and selectEntity maps
     await this.ready;
     await this.clearSelect();
@@ -341,6 +388,8 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
     for (const entityId of this.config.splitEntities || []) {
       if (!this.ha.hassEntities.has(entityId))
         this.log.warn(`Split entity "${CYAN}${entityId}${wr}" set in splitEntities not found in Home Assistant. Please check your configuration.`);
+      if (this.ha.hassEntities.has(entityId) && this.ha.hassEntities.get(entityId)?.device_id === null)
+        this.log.warn(`Split entity "${CYAN}${entityId}${wr}" set in splitEntities is an individual entity. Please check your configuration.`);
     }
 
     // *********************************************************************************************************
@@ -370,7 +419,10 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
         continue;
       }
       // If the entity doesn't have a valid name, we skip it.
-      const entityName = entity.name ?? entity.original_name;
+      const entityName =
+        this.config.splitNameStrategy === 'Friendly name'
+          ? (hassState.attributes?.friendly_name ?? entity.name ?? entity.original_name)
+          : (entity.name ?? entity.original_name ?? hassState.attributes?.friendly_name);
       if (!isValidString(entityName, 1)) {
         this.log.debug(`Individual entity ${CYAN}${entity.entity_id}${db} has no valid name. Skipping...`);
         continue;
@@ -549,7 +601,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       }
       // Apply area and label filters before the select and validation
       const hasValidEntities = Array.from(this.ha.hassEntities.values()).some(
-        (e) => e.device_id === device.id && e.disabled_by === null && this.isValidAreaLabel(e.area_id, e.labels),
+        (e) => e.device_id === device.id && e.disabled_by === null && this.isValidAreaLabel(e.area_id, e.labels, true), // Only check labels
       );
       const deviceHasValidAreaLabel = hasValidEntities ? false : this.isValidAreaLabel(device.area_id, device.labels);
       if (!hasValidEntities && !deviceHasValidAreaLabel) {
@@ -624,7 +676,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
           continue;
         }
         // Apply area and label filters before the select and validation
-        if (!deviceHasValidAreaLabel && !this.isValidAreaLabel(entity.area_id, entity.labels)) {
+        if (!deviceHasValidAreaLabel && !this.isValidAreaLabel(entity.area_id, entity.labels, true)) {
           this.filteredEntities++;
           this.log.info(
             `Device ${CYAN}${deviceName}${db} entity ${CYAN}${entity.entity_id}${db} is not in the area "${CYAN}${this.config.filterByArea}${db}" or doesn't have the label "${CYAN}${this.config.filterByLabel}${db}". Skipping...`,
@@ -747,7 +799,10 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
         continue;
       }
       // If the entity doesn't have a valid name, we skip it.
-      const entityName = entity.name ?? entity.original_name;
+      const entityName =
+        this.config.splitNameStrategy === 'Friendly name'
+          ? (hassState.attributes?.friendly_name ?? entity.name ?? entity.original_name)
+          : (entity.name ?? entity.original_name ?? hassState.attributes?.friendly_name);
       if (!isValidString(entityName, 1)) {
         this.log.debug(`Split entity ${CYAN}${entity.entity_id}${db} has no valid name. Skipping...`);
         continue;
@@ -768,7 +823,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
         continue;
       }
       // Apply area and label filters before the select and validation
-      if (!this.isValidAreaLabel(entity.area_id, entity.labels)) {
+      if (!this.isValidAreaLabel(entity.area_id, entity.labels, true)) {
         this.filteredEntities++;
         this.log.info(
           `Split entity ${CYAN}${entity.entity_id}${db} name ${CYAN}${entityName}${db} is not in the area "${CYAN}${this.config.filterByArea}${db}" or doesn't have the label "${CYAN}${this.config.filterByLabel}${db}". Skipping...`,
@@ -1323,6 +1378,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
    *
    * @param {string | null} area_id The area ID of the device / entity. It is null if the device / entity is not in any area.
    * @param {string[]} labels The labels ids of the device / entity. It is an empty array if the device / entity has no labels.
+   * @param {boolean} [labelOnly] If true, only the label filter will be applied, otherwise both area and label filters will be applied.
    *
    * @returns {boolean} True if the area and label are valid according to the filters, false otherwise.
    *
@@ -1330,19 +1386,12 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
    * "area_id" is the area ID of the device / entity. It is null if the device / entity is not in any area or a string with the area ID if it is in an area.
    * "labels" is an array of label IDs of the device / entity. It is an empty array if the device / entity has no labels.
    */
-  isValidAreaLabel(area_id: string | null, labels: string[]): boolean {
+  isValidAreaLabel(area_id: string | null, labels: string[], labelOnly: boolean = false): boolean {
     let areaMatch = true;
     let labelMatch = true;
 
     // Filter by area if configured
-    if (isValidString(this.config.filterByArea, 1)) {
-      /*
-      this.log.debug(
-        `Filtering by area "${CYAN}${this.config.filterByArea}${db}" area_id "${area_id}" registry "${Array.from(this.ha.hassAreas.values())
-          .map((area) => area.area_id + '=>"' + area.name + '"')
-          .join(', ')}"...`,
-      );
-      */
+    if (!labelOnly && isValidString(this.config.filterByArea, 1)) {
       if (!area_id) return false; // If the area_id is null, the device / entity is not in any area, so we skip it.
       areaMatch = false;
       const area = this.ha.hassAreas.get(area_id);
@@ -1352,13 +1401,6 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
 
     // Filter by label if configured.
     if (isValidString(this.config.filterByLabel, 1)) {
-      /*
-      this.log.debug(
-        `Filtering by label "${CYAN}${this.config.filterByLabel}${db}" labels (${labels.length}) "${labels.join(', ')}" registry "${Array.from(this.ha.hassLabels.values())
-          .map((label) => label.label_id + '=>"' + label.name + '"')
-          .join(', ')}"...`,
-      );
-      */
       if (labels.length === 0) return false; // If the labels array is empty, the device / entity has no labels, so we skip it.
       labelMatch = false;
       const label = Array.from(this.ha.hassLabels.values()).find((l) => l.name === this.config.filterByLabel);

--- a/src/module.ts
+++ b/src/module.ts
@@ -339,14 +339,14 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
     this.savePayload(path.join(this.matterbridge.matterbridgePluginDirectory, 'matterbridge-hass', 'homeassistant.json'));
 
     // Create a map of entity_id to device_id for quick lookup of the device of an entity
-    const areaId = this.ha.hassAreas.values().find((a) => a.name === this.config.filterByArea)?.area_id;
-    const labelId = this.ha.hassLabels.values().find((l) => l.name === this.config.filterByLabel)?.label_id;
+    const areaId = Array.from(this.ha.hassAreas.values()).find((a) => a.name === this.config.filterByArea)?.area_id;
+    const labelId = Array.from(this.ha.hassLabels.values()).find((l) => l.name === this.config.filterByLabel)?.label_id;
     const reportPath = path.join(this.matterbridge.matterbridgePluginDirectory, 'matterbridge-hass', 'report.log');
     writeFileSync(reportPath, `Home Assistant Devices and Entities Report\n\n`); // Create or overwrite the report file
     appendFileSync(reportPath, `Filter by area: ${this.config.filterByArea ? this.config.filterByArea + ' >>> ' + areaId : 'None'}\n\n`); // Create or overwrite the report file
     appendFileSync(reportPath, `Filter by label: ${this.config.filterByLabel ? this.config.filterByLabel + ' >>> ' + labelId : 'None'}\n\n`); // Create or overwrite the report file
     appendFileSync(reportPath, `Device Entities\n\n`);
-    for (const device of this.ha.hassDevices.values()) {
+    for (const device of Array.from(this.ha.hassDevices.values())) {
       appendFileSync(
         reportPath,
         `Device: "${device.name_by_user ?? device.name}"` +
@@ -356,7 +356,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
           `${labelId && device.labels?.includes(labelId) ? ' LABEL' : ''}` +
           `\n`,
       );
-      for (const entity of this.ha.hassEntities.values().filter((e) => e.device_id === device.id)) {
+      for (const entity of Array.from(this.ha.hassEntities.values()).filter((e) => e.device_id === device.id)) {
         const state = this.ha.hassStates.get(entity.entity_id);
         appendFileSync(
           reportPath,
@@ -369,7 +369,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       }
     }
     appendFileSync(reportPath, `\nIndividual Entities\n\n`);
-    for (const entity of this.ha.hassEntities.values().filter((e) => e.device_id === null)) {
+    for (const entity of Array.from(this.ha.hassEntities.values()).filter((e) => e.device_id === null)) {
       const state = this.ha.hassStates.get(entity.entity_id);
       appendFileSync(
         reportPath,

--- a/src/module.ts
+++ b/src/module.ts
@@ -1087,7 +1087,8 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
               serviceAttributes['color_temp_kelvin'] =
                 state && state.attributes.min_color_temp_kelvin && state.attributes.max_color_temp_kelvin
                   ? clamp(miredsToKelvin(color_temp, 'floor'), state.attributes.min_color_temp_kelvin, state.attributes.max_color_temp_kelvin)
-                  : miredsToKelvin(color_temp, 'floor');
+                  : // istanbul ignore next cause is just a safety check, it should never happen that we don't have the min and max color temp attributes
+                    miredsToKelvin(color_temp, 'floor');
           }
 
           if (


### PR DESCRIPTION
## [1.0.10] - 2026-03-09

### Breaking Changes

- [split]: The names of split entities may now be chosen using this logic:
  - `Friendly name` => `Name` => `Original name` (i.e. Computer Plug Child Lock). This avoids most duplicate-name issues, but the name will probably be truncated to 32 characters.
  - `Name` => `Original name` => `Friendly name` (i.e. Child Lock). This will probably create duplicate-name issues unless you change the name.

  If you change this option, check the whiteList and blackList if you use them.

### Added

- [report]: A new file `report.log` is generated in the `Matterbridge/matterbridge-hass` directory. It contains the list of devices and entities, highlighting whether they are in filterByArea, have filterByLabel, or are in splitEntities.
- [config]: Add the `splitNameStrategy` config option to select the naming strategy for split entities: `Entity name` (i.e. Child Lock) or `Friendly name` (i.e. Computer Plug Child Lock).

### Changed

- [package]: Update dependencies.
- [package]: Bump package to `automator` v.3.1.2.
- [package]: Bump `eslint` to v.10.0.3.

### Fixed

- [mireds]: Fix the maximum mireds value. Thanks jvmahon (https://github.com/Luligu/matterbridge/issues/523).
- [split]: Fix the name priority for split entities.
- [filter]: Ignore area for device entities and split entities.

<a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
