### PR TITLE
Release 1.2.0

### DIFF
--- a/.claude/rules/testing/unit-tests.instructions.md
+++ b/.claude/rules/testing/unit-tests.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Testing standards for unit tests in the project.'
-paths: ['packages/**/*.test.ts']
+paths: ['**/*.test.ts']
 ---
 
 # Testing Standards for Unit Tests

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -74,6 +74,7 @@ Dev containers have networking limitations depending on the host OS and Docker s
         "ms-azuretools.vscode-containers",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
+        "anthropic.claude-code",
         "github.copilot-chat",
         "github.vscode-github-actions",
         "github.vscode-pull-request-github"

--- a/.github/instructions/testing/unit-tests.instructions.md
+++ b/.github/instructions/testing/unit-tests.instructions.md
@@ -1,7 +1,7 @@
 ---
 name: 'Testing Standards'
 description: 'Testing standards for unit tests in the project.'
-applyTo: 'packages/**/*.test.ts'
+applyTo: '**/*.test.ts'
 ---
 
 # Testing Standards for Unit Tests

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .cache/
 .vscode/*
 !.vscode/tasks.json
+!.vscode/settings.json
 coverage/
 dist/
 jest/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,38 @@
+{
+  "terminal.integrated.scrollback": 10000,
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.format.enable": true,
+  "eslint.useFlatConfig": true,
+  "diffEditor.ignoreTrimWhitespace": false,
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.watcherExclude": {
+    "**/node_modules/**": true,
+    "**/build/**": true,
+    "**/.cache/**": true,
+    "**/coverage/**": true
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/dist": true,
+    "**/build": true,
+    "**/.cache": true,
+    "**/coverage": true
+  },
+  "git.autofetch": true,
+  "git.autoRepositoryDetection": false,
+  "git.ignoredRepositories": ["**/node_modules/**", "**/dist/**", "**/build/**", "**/.cache/**", "**/coverage/**", "**/docs/**"],
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": false,
+  "js/ts.tsserver.watchOptions": {
+    "watchFile": "dynamicPriorityPolling",
+    "watchDirectory": "dynamicPriorityPolling",
+    "fallbackPolling": "dynamicPriorityPolling",
+    "excludeDirectories": ["**/.cache/**", "**/node_modules/**", "**/coverage/**", "**/dist/**", "**/build/**", "**/docs/**"]
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,6 +9,13 @@
       "problemMatcher": []
     },
     {
+      "label": "Build and Start",
+      "detail": "npm run build and start",
+      "dependsOn": ["Build", "Start"],
+      "dependsOrder": "sequence",
+      "problemMatcher": []
+    },
+    {
       "label": "Build",
       "detail": "npm run build",
       "type": "npm",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ If you like this project and find it useful, please consider giving it a **star*
 ### Breaking Changes
 
 - [domains]: Domains `remote`, `select`, `input_select` and `media_player` are now supported. You may want to either use them with [filter](README.md#filter-by-label) and [select](README.md#device-entity-blacklist) or [exclude](README.md#domain-blacklist) all these domains if you don't need their entities or your controller doesn't support them.
+- [Split Entities]: The `Split Entities` config option is deprecated. Use `Split By Label`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ If you like this project and find it useful, please consider giving it a **star*
 
 > For naming issues (especially upsetting with Alexa), read the explanation and the solution [here](https://github.com/Luligu/matterbridge-hass/discussions/86).
 
-> The domains button, remote and media_player include an OnOff cluster. This will not make it possible to merge the entities on the same endpoint: if you have Alexa or Google you may want to either exclude those domains or to split their entities.
+> WARNING: The domains button, remote and media_player include an OnOff cluster. This will not make it possible to merge the entities on the same endpoint: if you have Alexa or Google you may want to either exclude those domains or to split their entities.
 
 ## [1.1.2] - Dev branch
 
@@ -30,7 +30,7 @@ If you like this project and find it useful, please consider giving it a **star*
 - [select]: Add `select` domain.
 - [input_select]: Add `input_select` domain.
 - [media_player]: Add `media_player` domain.
-- [Virtual Control]: Add the [Virtual Control Label](README.md#virtual-control-label) for accessibility controls on supported entities such as `select` and `media_player`.
+- [Virtual Control]: Add the [Virtual Control Label](README.md#virtual-control-label) for accessibility controls (voice-friendly switches) on supported entities such as `select`, `input_select` and `media_player`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,7 @@ If you like this project and find it useful, please consider giving it a **star*
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="120"></a>
 
-### How to use filters and select
-
-> Read the explanation [here](https://github.com/Luligu/matterbridge-hass/discussions/186).
-
-### Naming issues on the controller side explained
-
-> For naming issues (especially upsetting with Alexa), read the explanation and the solution [here](https://github.com/Luligu/matterbridge-hass/discussions/86).
+## Possible issue upgrading the plugin
 
 > WARNING: The domains button, remote and media_player include an OnOff cluster. This will not make it possible to merge the entities on the same endpoint: if you have Alexa or Google you may want to either exclude those domains or to split their entities.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,38 @@ If you like this project and find it useful, please consider giving it a **star*
 
 > For naming issues (especially upsetting with Alexa), read the explanation and the solution [here](https://github.com/Luligu/matterbridge-hass/discussions/86).
 
+## [1.1.2] - Dev branch
+
+### Added
+
+- [test]: Refactor tests to use the updated matterbridge test facility.
+
+### Changed
+
+- [package]: Preliminary compatibility update to `matterbridge 3.8.0`, matter 1.5.1 and matter.js 0.17.0.
+- [package]: Update dependencies.
+- [package]: Bump `typescript` to v.6.0.3.
+- [package]: Bump `eslint` to v.10.2.1.
+- [package]: Bump `typescript-eslint` to v.8.58.2.
+- [package]: Add `.vscode\settings.json`.
+- [devcontainer]: Add `Claude Code for VS Code extension` to Dev Container.
+
+<a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
+
 ## [1.1.1] - 2026-04-17
+
+### Breaking Changes
+
+- [binary_sensor]: The default implementation without device_class is a contact sensor. This will expose new entities.
+- [hidden]: All entities that are hidden are discarded unless `discardHiddenEntities` options is unchecked (reworked 1.0.4). Thanks kristian (https://github.com/Luligu/matterbridge-hass/issues/213).
 
 ### Added
 
 - [package]: Preliminary compatibility update to `matterbridge 3.8.0`, matter 1.5.1 and matter.js 0.17.0.
-- [hidden]: All entities that are hidden are discarded unless `discardHiddenEntities` options is unchecked. Thanks kristian (https://github.com/Luligu/matterbridge-hass/issues/213).
 - [report]: Update the `report` to show the hidden entities.
 - [readme]: Changed config headers in the [README](README.md#config) to reflect schema titles.
 - [select]: Add definitions for `select` and `input_select` domain.
 - [media_player]: Add definitions for `media_player` domain.
-- [binary_sensor]: The default implementation without device_class is a contact sensor.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,16 @@ If you like this project and find it useful, please consider giving it a **star*
 
 ## [1.1.2] - Dev branch
 
+### Breaking Changes
+
+- [domains]: New supported domains have been added. You may want to either add them with [filter](README.md#filter-by-label) and [select](README.md#device-entity-blacklist) or [exclude the domains](README.md#domain-blacklist) themself if your controller doesn't support them.
+
 ### Added
 
-- [test]: Refactor tests to use the updated matterbridge test facility.
+- [test]: Refactor tests to use the updated matterbridge test module.
+- [remote]: Add `remote` domain.
+- [select]: Add `select` domain.
+- [input_select]: Add `input_select` domain.
 
 ### Changed
 
@@ -26,7 +33,7 @@ If you like this project and find it useful, please consider giving it a **star*
 - [package]: Update dependencies.
 - [package]: Bump `typescript` to v.6.0.3.
 - [package]: Bump `eslint` to v.10.2.1.
-- [package]: Bump `typescript-eslint` to v.8.58.2.
+- [package]: Bump `typescript-eslint` to v.8.59.0.
 - [package]: Add `.vscode\settings.json`.
 - [devcontainer]: Add `Claude Code for VS Code extension` to Dev Container.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ If you like this project and find it useful, please consider giving it a **star*
 
 > For naming issues (especially upsetting with Alexa), read the explanation and the solution [here](https://github.com/Luligu/matterbridge-hass/discussions/86).
 
-> The domains button, remote and media_player include an OnOff cluster. This will not make it possible to merge the entities on the same endpoint: if you have Alexa of Google you may want to either exclude those domains or to split their entities.
+> The domains button, remote and media_player include an OnOff cluster. This will not make it possible to merge the entities on the same endpoint: if you have Alexa or Google you may want to either exclude those domains or to split their entities.
 
 ## [1.1.2] - Dev branch
 
 ### Breaking Changes
 
-- [domains]: Domains `select`, `input_select` and `media_player` are now supported. You may want to either add them with [filter](README.md#filter-by-label) and [select](README.md#device-entity-blacklist) or [exclude the domains](README.md#domain-blacklist) themself if your controller doesn't support them.
+- [domains]: Domains `remote`, `select`, `input_select` and `media_player` are now supported. You may want to either use them with [filter](README.md#filter-by-label) and [select](README.md#device-entity-blacklist) or [exclude](README.md#domain-blacklist) all these domains if you don't need their entities or your controller doesn't support them.
 
 ### Added
 
@@ -29,6 +29,7 @@ If you like this project and find it useful, please consider giving it a **star*
 - [select]: Add `select` domain.
 - [input_select]: Add `input_select` domain.
 - [media_player]: Add `media_player` domain.
+- [Virtual Control]: Add the [Virtual Control Label](README.md#virtual-control-label) for accessibility controls on supported entities such as `select` and `media_player`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ If you like this project and find it useful, please consider giving it a **star*
 
 > WARNING: The domains button, remote and media_player include an OnOff cluster. This will not make it possible to merge the entities on the same endpoint: if you have Alexa or Google you may want to either black list those domains or to split their entities.
 
-## [1.2.0] - Dev branch
+## [1.2.0] - 2026-04-24
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ If you like this project and find it useful, please consider giving it a **star*
 - [remote]: Add `remote` domain.
 - [select]: Add `select` domain.
 - [input_select]: Add `input_select` domain.
+- [media_player]: Add `media_player` domain.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ If you like this project and find it useful, please consider giving it a **star*
 
 > For naming issues (especially upsetting with Alexa), read the explanation and the solution [here](https://github.com/Luligu/matterbridge-hass/discussions/86).
 
+> The domains button, remote and media_player include an OnOff cluster. This will not make it possible to merge the entities on the same endpoint: if you have Alexa of Google you may want to either exclude those domains or to split their entities.
+
 ## [1.1.2] - Dev branch
 
 ### Breaking Changes
 
-- [domains]: New supported domains have been added. You may want to either add them with [filter](README.md#filter-by-label) and [select](README.md#device-entity-blacklist) or [exclude the domains](README.md#domain-blacklist) themself if your controller doesn't support them.
+- [domains]: Domains `select`, `input_select` and `media_player` are now supported. You may want to either add them with [filter](README.md#filter-by-label) and [select](README.md#device-entity-blacklist) or [exclude the domains](README.md#domain-blacklist) themself if your controller doesn't support them.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ If you like this project and find it useful, please consider giving it a **star*
 
 ## Possible issue upgrading the plugin
 
-> WARNING: The domains button, remote and media_player include an OnOff cluster. This will not make it possible to merge the entities on the same endpoint: if you have Alexa or Google you may want to either exclude those domains or to split their entities.
+> WARNING: The domains button, remote and media_player include an OnOff cluster. This will not make it possible to merge the entities on the same endpoint: if you have Alexa or Google you may want to either black list those domains or to split their entities.
 
-## [1.1.2] - Dev branch
+## [1.2.0] - Dev branch
 
 ### Breaking Changes
 
-- [domains]: Domains `remote`, `select`, `input_select` and `media_player` are now supported. You may want to either use them with [filter](README.md#filter-by-label) and [select](README.md#device-entity-blacklist) or [exclude](README.md#domain-blacklist) all these domains if you don't need their entities or your controller doesn't support them.
+- [domains]: Domains `remote`, `select`, `input_select` and `media_player` are now supported. You may want to either use them with [filter](README.md#filter-by-label) and [select](README.md#device-entity-blacklist) or [exclude](README.md#domain-blacklist) all these domains if you don't need their entities or your controller doesn't support them. It is also possible to split them.
 - [Split Entities]: The `Split Entities` config option is deprecated. Use `Split By Label`.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -312,18 +312,20 @@ Label used to enable virtual controls on entities. If set, the plugin creates on
 
 Supported virtual control domains:
 
-| Domain       | Feature        | Service              | Virtual control |
-| ------------ | -------------- | -------------------- | --------------- |
-| media_player | TURN_ON        | TURN_ON              | Turn ON         |
-|              | TURN_OFF       | TURN_OFF             | Turn OFF        |
-|              | PLAY           | MEDIA_PLAY           | Play            |
-|              | PAUSE          | MEDIA_PAUSE          | Pause           |
-|              | STOP           | MEDIA_STOP           | Stop            |
-|              | VOLUME_MUTE    | VOLUME_MUTE          | Mute            |
-|              | VOLUME_STEP    | VOLUME_DOWN          | Volume Down     |
-|              | VOLUME_STEP    | VOLUME_UP            | Volume Up       |
-|              | PREVIOUS_TRACK | MEDIA_PREVIOUS_TRACK | Previous Track  |
-|              | NEXT_TRACK     | MEDIA_NEXT_TRACK     | Next Track      |
+| Domain       | Feature        | Service              | Virtual control       |
+| ------------ | -------------- | -------------------- | --------------------- |
+| media_player | TURN_ON        | TURN_ON              | Turn ON + name        |
+|              | TURN_OFF       | TURN_OFF             | Turn OFF + name       |
+|              | PLAY           | MEDIA_PLAY           | Play + name           |
+|              | PAUSE          | MEDIA_PAUSE          | Pause + name          |
+|              | STOP           | MEDIA_STOP           | Stop + name           |
+|              | VOLUME_MUTE    | VOLUME_MUTE          | Mute + name           |
+|              | VOLUME_STEP    | VOLUME_DOWN          | Volume Down + name    |
+|              | VOLUME_STEP    | VOLUME_UP            | Volume Up + name      |
+|              | PREVIOUS_TRACK | MEDIA_PREVIOUS_TRACK | Previous Track + name |
+|              | NEXT_TRACK     | MEDIA_NEXT_TRACK     | Next Track + name     |
+| select       |                |                      | name + all options    |
+| input_select |                |                      | name + all options    |
 
 Use this option to create simple voice-friendly switches like `Play TV`, `Pause TV`, or `Turn ON TV` for supported media players: with Siri you can simply say `Hey Siri Play TV`.
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ Entities whose domain is listed here will be excluded. Leave this list empty to 
 
 ### Split Entities
 
+DEPRECATED: use `Split By Label`
+
 The device entities in the list will be exposed like an independent device and removed from their device. Use the entity id (i.e. switch.plug_child_lock).
 
 Let's make an example.
@@ -279,7 +281,7 @@ Strategy used for split entity names. "Entity name": use the entity name (i.e. C
 
 ### Controller Strategy
 
-Strategy used to expose multiple device types. 'Merge' combines non-overlapping device types on the main endpoint. 'Matter' creates a separate endpoint for each device type. Use the Merge strategy for legacy controllers (more then one application device type on the same bridged endpoint is not compliant in Matter 1.5.0). Changing this setting may require you to pair the controller again cause the entire node is composed differently.
+Strategy used to expose multiple device types. 'Merge' combines non-overlapping device types on the main endpoint. 'Matter' creates a separate endpoint for each device type. Use the Merge strategy for legacy controllers (more then one application device type on the same bridged endpoint is not strictly compliant in Matter 1.5.0). Changing this setting may require you to pair the controller again cause the entire node is composed differently.
 
 ### Air Quality Regex
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ If enabled (default), the plugin discards entities that are hidden in Home Assis
 
 ### Virtual Control Label
 
-Label used to enable virtual controls on entities. If set, the plugin creates one virtual control for each entity with the selected label. These virtual controls are intended for accessibility and let you send commands to entities that are not directly supported by the controller, such as `media_player.samsung_tv`. Virtual controls are exposed as switch entities: turning one on triggers the command, and the plugin automatically turns it off again afterward.
+Label used to enable virtual controls on entities. If set, the plugin creates one virtual control for each entity with the selected label. These virtual controls are intended for accessibility and let you send commands to entities that are not directly supported by the controller, such as `media_player.samsung_tv`, with simple voice-friendly switches. Virtual controls are exposed as switch entities: turning one on triggers the command, and the plugin automatically turns it off again afterward.
 
 Supported virtual control domains:
 
@@ -353,9 +353,10 @@ Supported virtual control domains:
 | select       |                |                      | name + all options    |
 | input_select |                |                      | name + all options    |
 
-Use this option to create simple voice-friendly switches like `Play TV`, `Pause TV`, or `Turn ON TV` for supported media players: with Siri you can simply say `Hey Siri Play TV`.
+Use this option to create simple voice-friendly switches like `Play TV`, `Pause TV`, or `Turn ON TV` for media_player domain: with Siri you can simply say `Hey Siri Play TV`.
 
 Example:
+
 Let's say you have a device named `Samsung TV` with a media_player entity `media_player.samsung_tv`.
 
 If you set `Virtual Control Label` to `matterbridge-virtual` and assign that label to the media_player entity in Home Assistant, the plugin checks which media player features are supported and creates one virtual switch for each supported command.

--- a/README.md
+++ b/README.md
@@ -304,6 +304,53 @@ In addition to this well known bugs, the rvc must be a single device, it cannot 
 
 If enabled (default), the plugin discards entities that are hidden in Home Assistant (i.e. entities whose `hidden_by` field is not `null` in the entity registry). Hidden entities will not be exposed as device entities, individual entities, or split entities.
 
+### Virtual Control Label
+
+Label used to enable virtual controls on entities. If set, the plugin creates one virtual control for each entity with the selected label. These virtual controls are intended for accessibility and let you send commands to entities that are not directly supported by the controller, such as `media_player.samsung_tv`. Virtual controls are exposed as switch entities: turning one on triggers the command, and the plugin automatically turns it off again afterward.
+
+Supported virtual control domains:
+
+| Domain       | Feature        | Service              | Virtual control |
+| ------------ | -------------- | -------------------- | --------------- |
+| media_player | TURN_ON        | TURN_ON              | Turn ON         |
+|              | TURN_OFF       | TURN_OFF             | Turn OFF        |
+|              | PLAY           | MEDIA_PLAY           | Play            |
+|              | PAUSE          | MEDIA_PAUSE          | Pause           |
+|              | STOP           | MEDIA_STOP           | Stop            |
+|              | VOLUME_MUTE    | VOLUME_MUTE          | Mute            |
+|              | VOLUME_STEP    | VOLUME_DOWN          | Volume Down     |
+|              | VOLUME_STEP    | VOLUME_UP            | Volume Up       |
+|              | PREVIOUS_TRACK | MEDIA_PREVIOUS_TRACK | Previous Track  |
+|              | NEXT_TRACK     | MEDIA_NEXT_TRACK     | Next Track      |
+
+Use this option to create simple voice-friendly switches like `Play TV`, `Pause TV`, or `Turn ON TV` for supported media players: with Siri you can simply say `Hey Siri Play TV`.
+
+Example:
+Let's say you have a device named `Samsung TV` with a media_player entity `media_player.samsung_tv`.
+
+If you set `Virtual Control Label` to `matterbridge-virtual` and assign that label to the media_player entity in Home Assistant, the plugin checks which media player features are supported and creates one virtual switch for each supported command.
+
+For example:
+
+- if the device supports `TURN_ON`, the plugin creates `Turn ON Samsung TV`
+- if the device supports `TURN_OFF`, the plugin creates `Turn OFF Samsung TV`
+- if the device supports `PLAY`, the plugin creates `Play Samsung TV`
+- if the device supports `PAUSE`, the plugin creates `Pause Samsung TV`
+- if the device supports `STOP`, the plugin creates `Stop Samsung TV`
+- if the device supports `VOLUME_MUTE`, the plugin creates `Mute Samsung TV`
+- if the device supports `VOLUME_STEP`, the plugin creates `Volume Down Samsung TV` and `Volume Up Samsung TV`
+- if the device supports `PREVIOUS_TRACK`, the plugin creates `Previous Track Samsung TV`
+- if the device supports `NEXT_TRACK`, the plugin creates `Next Track Samsung TV`
+
+When you turn on one of these virtual switches, the plugin sends the corresponding `media_player` service command to that entity and then automatically turns the switch off again.
+
+So, if your `Samsung TV` only supports `TURN_ON`, `TURN_OFF` and `VOLUME_STEP`, you will get these four virtual controls:
+
+- `Turn ON Samsung TV`
+- `Turn OFF Samsung TV`
+- `Volume Down Samsung TV`
+- `Volume Up Samsung TV`
+
 ### Enable Debug
 
 Should be enabled only if you want to debug some issue using the log.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ Features:
 - Support system unit **CELSIUS** and **FAHRENHEIT**.
 - Jest test coverage = 100%.
 
+## How to use filters and select
+
+> Read the explanation [here](https://github.com/Luligu/matterbridge-hass/discussions/186).
+
+## Naming issues on the controller side explained
+
+> For naming issues (especially upsetting with Alexa and Google), read the explanation and the solution [here](https://github.com/Luligu/matterbridge-hass/discussions/86).
+
+## Quick install guide
+
+For new users I suggest to start following this list:
+
+- create an [Home Assistant Token](README.md#token)
+- create an Home Assistant Label that will be used to [filter](README.md#filter-by-label) the devices and entities in Home Assistant
+- create an Home Assistant Label that will be used to [split](README.md#split-by-label) the device entities in Home Assistant
+- find your [Host name or Address](README.md#host)
+- add them to the config and restart
+
+Now add the `label for filter` you created before to each device you want to expose to Matter (or to each device entity if you want only some of the device entities).
+
+Add also the `label for split` you created before to each device entity you want to expose like a single Matter device.
+
+Restart, verify that everything is like you intended.
+
+Pair Matterbridge to your controller.
+
 ## Supported device entities:
 
 | Domain       | Supported states                           | Supported attributes                                                                    |
@@ -238,7 +264,7 @@ Entities whose domain is listed here will be excluded. Leave this list empty to 
 
 ### Split Entities
 
-DEPRECATED: use `Split By Label`
+> DEPRECATED: use `Split By Label`
 
 The device entities in the list will be exposed like an independent device and removed from their device. Use the entity id (i.e. switch.plug_child_lock).
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Features:
 | valve      | open, closed, opening, closing            | current_position                                                                        |
 | vacuum (2) | idle, cleaning, paused, docked, returning |                                                                                         |
 | button     |                                           |                                                                                         |
+| remote     | on, off                                   |                                                                                         |
+| select     |                                           | options                                                                                 |
 
 (1) - Supported preset_modes: auto, low, medium, high.
 
@@ -70,6 +72,7 @@ These domains are supported also like individual and split entities.
 | script        | Scripts     |
 | input_boolean | Helpers     |
 | input_button  | Helpers     |
+| input_select  | Helpers     |
 
 These individual entities are exposed as on/off outlets. When the outlet is turned on, it triggers the associated entity. After triggering, the outlet automatically switches back to the off state. The helper of domain input_boolean maintains the on/off state.
 

--- a/README.md
+++ b/README.md
@@ -43,19 +43,20 @@ Features:
 
 ## Supported device entities:
 
-| Domain     | Supported states                          | Supported attributes                                                                    |
-| ---------- | ----------------------------------------- | --------------------------------------------------------------------------------------- |
-| switch     | on, off                                   |                                                                                         |
-| light      | on, off                                   | brightness, color_mode, color_temp, hs_color, xy_color                                  |
-| lock       | locked, locking, unlocking, unlocked      |                                                                                         |
-| fan        | on, off                                   | percentage, preset_mode (1), direction, oscillating                                     |
-| cover      | open, closed, opening, closing            | current_position                                                                        |
-| climate    | off, heat, cool, heat_cool, auto          | current_temperature, temperature, target_temp_low, target_temp_high, min_temp, max_temp |
-| valve      | open, closed, opening, closing            | current_position                                                                        |
-| vacuum (2) | idle, cleaning, paused, docked, returning |                                                                                         |
-| button     |                                           |                                                                                         |
-| remote     | on, off                                   |                                                                                         |
-| select     |                                           | options                                                                                 |
+| Domain       | Supported states                           | Supported attributes                                                                    |
+| ------------ | ------------------------------------------ | --------------------------------------------------------------------------------------- |
+| switch       | on, off                                    |                                                                                         |
+| light        | on, off                                    | brightness, color_mode, color_temp, hs_color, xy_color                                  |
+| lock         | locked, locking, unlocking, unlocked       |                                                                                         |
+| fan          | on, off                                    | percentage, preset_mode (1), direction, oscillating                                     |
+| cover        | open, closed, opening, closing             | current_position                                                                        |
+| climate      | off, heat, cool, heat_cool, auto           | current_temperature, temperature, target_temp_low, target_temp_high, min_temp, max_temp |
+| valve        | open, closed, opening, closing             | current_position                                                                        |
+| vacuum (2)   | idle, cleaning, paused, docked, returning  |                                                                                         |
+| button       |                                            |                                                                                         |
+| remote       | on, off                                    |                                                                                         |
+| select       |                                            | options                                                                                 |
+| media_player | on, off, play, pause, stop, previous, next |                                                                                         |
 
 (1) - Supported preset_modes: auto, low, medium, high.
 

--- a/matterbridge-hass.config.json
+++ b/matterbridge-hass.config.json
@@ -24,6 +24,7 @@
   "airQualityRegex": "",
   "enableServerRvc": true,
   "discardHiddenEntities": true,
+  "virtualControlLabel": "",
   "debug": false,
   "unregisterOnShutdown": false
 }

--- a/matterbridge-hass.schema.json
+++ b/matterbridge-hass.schema.json
@@ -126,7 +126,8 @@
           "button",
           "remote",
           "select",
-          "input_select"
+          "input_select",
+          "media_player"
         ]
       },
       "uniqueItems": true
@@ -157,7 +158,8 @@
           "button",
           "remote",
           "select",
-          "input_select"
+          "input_select",
+          "media_player"
         ]
       },
       "uniqueItems": true

--- a/matterbridge-hass.schema.json
+++ b/matterbridge-hass.schema.json
@@ -165,7 +165,7 @@
       "uniqueItems": true
     },
     "splitEntities": {
-      "title": "Split Entities",
+      "title": "Split Entities (DEPRECATED: use Split By Label)",
       "description": "The device entities in the list will be exposed like an independent device and removed from their device. Enter the entity_id (i.e. switch.computer_plug_child_lock). Split entities must satisfy the filters (if any) and the whiteList (if any).",
       "type": "array",
       "items": {

--- a/matterbridge-hass.schema.json
+++ b/matterbridge-hass.schema.json
@@ -223,6 +223,12 @@
       "type": "boolean",
       "default": true
     },
+    "virtualControlLabel": {
+      "title": "Virtual Control Label",
+      "description": "Label to activates virtual control commands on entities (use label name). If enabled, a virtual control will be created for each entity with the selected label. Virtual controls are used to send commands to entities that are not directly supported by the controller (e.g., media_player.apple_tv). Virtual controls will be exposed as switch entities and will trigger a command when turned on. The plugin will turn off the virtual control after the command is triggered.",
+      "type": "string",
+      "default": ""
+    },
     "debug": {
       "title": "Enable Debug",
       "description": "Enable the debug for the plugin (development only)",

--- a/matterbridge-hass.schema.json
+++ b/matterbridge-hass.schema.json
@@ -123,7 +123,10 @@
           "sensor",
           "binary_sensor",
           "event",
-          "button"
+          "button",
+          "remote",
+          "select",
+          "input_select"
         ]
       },
       "uniqueItems": true
@@ -151,7 +154,10 @@
           "sensor",
           "binary_sensor",
           "event",
-          "button"
+          "button",
+          "remote",
+          "select",
+          "input_select"
         ]
       },
       "uniqueItems": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge-hass",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-hass",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "node-ansi-logger": "3.2.1",
@@ -2777,9 +2777,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3578,14 +3578,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1426,9 +1426,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.126.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
-      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1460,9 +1460,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -1477,9 +1477,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -1494,9 +1494,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -1511,9 +1511,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -1528,9 +1528,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
-      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -1545,9 +1545,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
@@ -1565,9 +1565,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
@@ -1585,9 +1585,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
@@ -1605,9 +1605,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
@@ -1625,9 +1625,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -1645,9 +1645,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -1665,9 +1665,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -1682,9 +1682,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -1692,35 +1692,12 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
         "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
@@ -1743,9 +1720,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -1760,9 +1737,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -1777,9 +1754,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
-      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3040,9 +3017,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
-      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3564,9 +3541,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.343",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz",
-      "integrity": "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true,
       "license": "ISC"
     },
@@ -7731,14 +7708,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.126.0",
-        "@rolldown/pluginutils": "1.0.0-rc.16"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -7747,21 +7724,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/run-parallel": {
@@ -8885,16 +8862,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
-      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.16",
+        "rolldown": "1.0.0-rc.17",
         "tinyglobby": "^0.2.16"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge-hass",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-hass",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "node-ansi-logger": "3.2.1",
@@ -24,7 +24,7 @@
         "@vitest/coverage-v8": "4.1.4",
         "@vitest/eslint-plugin": "1.6.16",
         "cross-env": "10.1.0",
-        "eslint": "10.2.0",
+        "eslint": "10.2.1",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-jest": "29.15.2",
         "eslint-plugin-jsdoc": "62.9.0",
@@ -33,11 +33,11 @@
         "eslint-plugin-promise": "7.2.1",
         "eslint-plugin-simple-import-sort": "13.0.0",
         "jest": "30.3.0",
-        "npm-check-updates": "21.0.1",
+        "npm-check-updates": "21.0.2",
         "prettier": "3.8.3",
         "shx": "0.4.0",
         "ts-jest": "29.4.9",
-        "typescript": "6.0.2",
+        "typescript": "6.0.3",
         "typescript-eslint": "8.58.2",
         "vitest": "4.1.4"
       },
@@ -801,25 +801,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1412,9 +1426,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
+      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1446,9 +1460,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
       "cpu": [
         "arm64"
       ],
@@ -1463,9 +1477,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
       "cpu": [
         "arm64"
       ],
@@ -1480,9 +1494,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
       "cpu": [
         "x64"
       ],
@@ -1497,9 +1511,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
       "cpu": [
         "x64"
       ],
@@ -1514,9 +1528,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
+      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
       "cpu": [
         "arm"
       ],
@@ -1531,9 +1545,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
       "cpu": [
         "arm64"
       ],
@@ -1551,9 +1565,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
       "cpu": [
         "arm64"
       ],
@@ -1571,9 +1585,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1591,9 +1605,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
       "cpu": [
         "s390x"
       ],
@@ -1611,9 +1625,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
       "cpu": [
         "x64"
       ],
@@ -1631,9 +1645,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
       "cpu": [
         "x64"
       ],
@@ -1651,9 +1665,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
       "cpu": [
         "arm64"
       ],
@@ -1668,9 +1682,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
       "cpu": [
         "wasm32"
       ],
@@ -1680,10 +1694,10 @@
       "dependencies": {
         "@emnapi/core": "1.9.2",
         "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
@@ -1729,9 +1743,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1746,9 +1760,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
       "cpu": [
         "x64"
       ],
@@ -1763,9 +1777,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
+      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3026,9 +3040,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3550,9 +3564,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.339",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
-      "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3651,18 +3665,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
-      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.4",
-        "@eslint/config-helpers": "^0.5.4",
-        "@eslint/core": "^1.2.0",
-        "@eslint/plugin-kit": "^0.7.0",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -4558,9 +4572,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7102,9 +7116,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-21.0.1.tgz",
-      "integrity": "sha512-BwYXOxntt5uQsLHcKw/z1awNAW1USfzQwMiBoKyCMlFi7hIVQKiMv3TJvJaHppZxmYkjvhnuogroN374Jsupvw==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-21.0.2.tgz",
+      "integrity": "sha512-b4o+4hbTOZW1gDPcM3wRpIgaB+Vyn/c6MFG2aw70Mo84f0toUulXUJtA1cncBv5BEZqUyotHFv6FR7aIN3Sq1w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7717,14 +7731,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.126.0",
+        "@rolldown/pluginutils": "1.0.0-rc.16"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -7733,21 +7747,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
       }
     },
     "node_modules/run-parallel": {
@@ -8647,9 +8661,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8871,17 +8885,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
+      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.16",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/jest": "30.0.0",
         "@types/node": "25.6.0",
         "@types/ws": "8.18.1",
-        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/coverage-v8": "4.1.5",
         "@vitest/eslint-plugin": "1.6.16",
         "cross-env": "10.1.0",
         "eslint": "10.2.1",
@@ -33,13 +33,13 @@
         "eslint-plugin-promise": "7.2.1",
         "eslint-plugin-simple-import-sort": "13.0.0",
         "jest": "30.3.0",
-        "npm-check-updates": "21.0.2",
+        "npm-check-updates": "21.0.3",
         "prettier": "3.8.3",
         "shx": "0.4.0",
         "ts-jest": "29.4.9",
         "typescript": "6.0.3",
-        "typescript-eslint": "8.58.2",
-        "vitest": "4.1.4"
+        "typescript-eslint": "8.59.0",
+        "vitest": "4.1.5"
       },
       "engines": {
         "node": ">=20.19.0 <21.0.0 || >=22.13.0 <23.0.0 || >=24.0.0 <25.0.0"
@@ -2059,17 +2059,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
-      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/type-utils": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2082,7 +2082,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.2",
+        "@typescript-eslint/parser": "^8.59.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2098,16 +2098,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2123,14 +2123,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2145,14 +2145,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2163,9 +2163,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2180,15 +2180,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
-      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2205,9 +2205,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2219,16 +2219,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2247,16 +2247,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2"
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2271,13 +2271,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.59.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2602,14 +2602,14 @@
       ]
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
-      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -2623,8 +2623,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.4",
-        "vitest": "4.1.4"
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -2664,16 +2664,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2682,13 +2682,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2709,9 +2709,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2722,13 +2722,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2736,14 +2736,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2752,9 +2752,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2762,13 +2762,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -3163,9 +3163,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
       "dev": true,
       "funding": [
         {
@@ -3564,9 +3564,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.340",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
-      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+      "version": "1.5.343",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz",
+      "integrity": "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==",
       "dev": true,
       "license": "ISC"
     },
@@ -7099,9 +7099,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7116,9 +7116,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-21.0.2.tgz",
-      "integrity": "sha512-b4o+4hbTOZW1gDPcM3wRpIgaB+Vyn/c6MFG2aw70Mo84f0toUulXUJtA1cncBv5BEZqUyotHFv6FR7aIN3Sq1w==",
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-21.0.3.tgz",
+      "integrity": "sha512-8y0fqtxdo5JhwzxcS9rZd969tvPbSZ3MzQoG5Fj8eqL42t1Jsg5tjZCz8CYuXLE8LNbbyV+1xxR/f/T4AdPmdg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8352,9 +8352,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8675,16 +8675,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
-      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
+      "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.2",
-        "@typescript-eslint/parser": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2"
+        "@typescript-eslint/eslint-plugin": "8.59.0",
+        "@typescript-eslint/parser": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8963,19 +8963,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -9003,12 +9003,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-hass",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Matterbridge hass plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-hass",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Matterbridge hass plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",
@@ -134,7 +134,7 @@
     "@vitest/coverage-v8": "4.1.4",
     "@vitest/eslint-plugin": "1.6.16",
     "cross-env": "10.1.0",
-    "eslint": "10.2.0",
+    "eslint": "10.2.1",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-jest": "29.15.2",
     "eslint-plugin-jsdoc": "62.9.0",
@@ -143,16 +143,16 @@
     "eslint-plugin-promise": "7.2.1",
     "eslint-plugin-simple-import-sort": "13.0.0",
     "jest": "30.3.0",
-    "npm-check-updates": "21.0.1",
+    "npm-check-updates": "21.0.2",
     "prettier": "3.8.3",
     "shx": "0.4.0",
     "ts-jest": "29.4.9",
-    "typescript": "6.0.2",
+    "typescript": "6.0.3",
     "typescript-eslint": "8.58.2",
     "vitest": "4.1.4"
   },
   "overrides": {
-    "eslint": "10.2.0",
+    "eslint": "10.2.1",
     "@eslint/js": "10.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@types/jest": "30.0.0",
     "@types/node": "25.6.0",
     "@types/ws": "8.18.1",
-    "@vitest/coverage-v8": "4.1.4",
+    "@vitest/coverage-v8": "4.1.5",
     "@vitest/eslint-plugin": "1.6.16",
     "cross-env": "10.1.0",
     "eslint": "10.2.1",
@@ -143,13 +143,13 @@
     "eslint-plugin-promise": "7.2.1",
     "eslint-plugin-simple-import-sort": "13.0.0",
     "jest": "30.3.0",
-    "npm-check-updates": "21.0.2",
+    "npm-check-updates": "21.0.3",
     "prettier": "3.8.3",
     "shx": "0.4.0",
     "ts-jest": "29.4.9",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.58.2",
-    "vitest": "4.1.4"
+    "typescript-eslint": "8.59.0",
+    "vitest": "4.1.5"
   },
   "overrides": {
     "eslint": "10.2.1",

--- a/src/control.entity.test.ts
+++ b/src/control.entity.test.ts
@@ -206,6 +206,69 @@ describe('addControlEntity', () => {
     expect(args[2]).toEqual(attributes.options);
   });
 
+  it('registers labeled input_select virtual controls for each option', async () => {
+    const [md, e, s] = make('input_select', 'mode', {
+      friendly_name: 'Heating Mode',
+      options: ['Eco', 'Comfort'],
+    });
+    const callService = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const registerVirtualDevice = jest.fn();
+    const platform = {
+      ...mockPlatform,
+      config: { splitNameStrategy: 'Friendly name', virtualControlLabel: 'Virtual Controls' },
+      ha: {
+        callService,
+        hassLabels: new Map([['virtual-controls', { label_id: 'virtual-controls', name: 'Virtual Controls' }]]),
+        hassStates: new Map([[e.entity_id, s]]),
+      },
+      registerVirtualDevice,
+    } as any;
+    const entity = { ...e, labels: ['virtual-controls'] } as HassEntity;
+
+    addControlEntity(platform, md, entity, s, commandHandler, subscribeHandler as any);
+
+    expect(registerVirtualDevice).toHaveBeenCalledTimes(2);
+    expect(registerVirtualDevice).toHaveBeenNthCalledWith(1, 'Heating Mode Eco', 'mounted_switch', expect.any(Function));
+    expect(registerVirtualDevice).toHaveBeenNthCalledWith(2, 'Heating Mode Comfort', 'mounted_switch', expect.any(Function));
+
+    const comfortCallback = registerVirtualDevice.mock.calls[1][2] as VirtualDeviceCallback;
+    await comfortCallback();
+    await Promise.resolve();
+
+    expect(callService).toHaveBeenCalledWith('input_select', 'select_option', e.entity_id, { option: 'Comfort' });
+  });
+
+  it('logs an error when a labeled input_select virtual control service call fails', async () => {
+    const [md, e, s] = make('input_select', 'mode', {
+      friendly_name: 'Heating Mode',
+      options: ['Eco'],
+    });
+    const callService = jest.fn<() => Promise<void>>().mockRejectedValue(new Error('boom'));
+    const registerVirtualDevice = jest.fn();
+    const log = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    const platform = {
+      config: { splitNameStrategy: 'Friendly name', virtualControlLabel: 'Virtual Controls' },
+      ha: {
+        callService,
+        hassLabels: new Map([['virtual-controls', { label_id: 'virtual-controls', name: 'Virtual Controls' }]]),
+        hassStates: new Map([[e.entity_id, s]]),
+      },
+      log,
+      registerVirtualDevice,
+    } as any;
+    const entity = { ...e, labels: ['virtual-controls'] } as HassEntity;
+
+    addControlEntity(platform, md, entity, s, commandHandler, subscribeHandler as any);
+
+    const ecoCallback = registerVirtualDevice.mock.calls[0][2] as VirtualDeviceCallback;
+    await ecoCallback();
+    await Promise.resolve();
+
+    expect(callService).toHaveBeenCalledWith('input_select', 'select_option', e.entity_id, { option: 'Eco' });
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining('Failed to call select_option service for'));
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining('Error: boom'));
+  });
+
   it('configures remote entities with on/off support', () => {
     const [md, e, s] = make('remote', 'tv', {});
 

--- a/src/control.entity.test.ts
+++ b/src/control.entity.test.ts
@@ -15,7 +15,7 @@ import {
 
 import { addControlEntity } from './control.entity.js';
 import { hassCommandConverter, hassDomainConverter, hassSubscribeConverter } from './converters.js';
-import { type HassConfig, type HassEntity, type HassState, HomeAssistant, UnitOfTemperature } from './homeAssistant.js';
+import { type HassConfig, type HassEntity, type HassState, HomeAssistant, MediaPlayerEntityFeature, MediaPlayerService, UnitOfTemperature } from './homeAssistant.js';
 import { MutableDevice } from './mutableDevice.js';
 
 function createMockMutableDevice(): MutableDevice {
@@ -54,10 +54,11 @@ function createMockMutableDevice(): MutableDevice {
   } as unknown as MutableDevice;
 }
 
-const mockLog = { debug: jest.fn(), warn: jest.fn() } as any;
-const mockPlatform = { log: mockLog } as any;
+const mockLog = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any;
+const mockPlatform = { config: { virtualControlLabel: '' }, log: mockLog } as any;
 const commandHandler = jest.fn(async () => {}); // async signature required
 const subscribeHandler = jest.fn();
+type VirtualDeviceCallback = () => Promise<void>;
 
 describe('addControlEntity', () => {
   beforeEach(() => jest.clearAllMocks());
@@ -223,6 +224,69 @@ describe('addControlEntity', () => {
     expect(md.addOnOff).toHaveBeenCalledWith(e.entity_id, true);
     expect(md.addBasicVideoPlayer).toHaveBeenCalledWith(e.entity_id);
     expect(md.addKeypadInput).toHaveBeenCalledWith(e.entity_id);
+  });
+
+  it('registers labeled media player virtual controls for supported features', async () => {
+    const [md, e, s] = make('media_player', 'tv', {
+      friendly_name: 'Living Room TV',
+      supported_features: MediaPlayerEntityFeature.TURN_ON | MediaPlayerEntityFeature.VOLUME_STEP,
+    });
+    const callService = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const registerVirtualDevice = jest.fn();
+    const platform = {
+      ...mockPlatform,
+      config: { splitNameStrategy: 'Friendly name', virtualControlLabel: 'Virtual Controls' },
+      ha: {
+        callService,
+        hassLabels: new Map([['virtual-controls', { label_id: 'virtual-controls', name: 'Virtual Controls' }]]),
+        hassStates: new Map([[e.entity_id, s]]),
+      },
+      registerVirtualDevice,
+    } as any;
+    const entity = { ...e, labels: ['virtual-controls'] } as HassEntity;
+
+    addControlEntity(platform, md, entity, s, commandHandler, subscribeHandler as any);
+
+    expect(registerVirtualDevice).toHaveBeenCalledTimes(3);
+    expect(registerVirtualDevice).toHaveBeenNthCalledWith(1, 'Turn ON Living Room TV', 'mounted_switch', expect.any(Function));
+    expect(registerVirtualDevice).toHaveBeenNthCalledWith(2, 'Volume Down Living Room TV', 'mounted_switch', expect.any(Function));
+    expect(registerVirtualDevice).toHaveBeenNthCalledWith(3, 'Volume Up Living Room TV', 'mounted_switch', expect.any(Function));
+
+    const volumeUpCallback = registerVirtualDevice.mock.calls[2][2] as VirtualDeviceCallback;
+    await volumeUpCallback();
+
+    expect(callService).toHaveBeenCalledWith('media_player', MediaPlayerService.VOLUME_UP, e.entity_id);
+  });
+
+  it('logs an error when a labeled media player virtual control service call fails', async () => {
+    const [md, e, s] = make('media_player', 'tv', {
+      friendly_name: 'Living Room TV',
+      supported_features: MediaPlayerEntityFeature.TURN_ON,
+    });
+    const callService = jest.fn<() => Promise<void>>().mockRejectedValue(new Error('boom'));
+    const registerVirtualDevice = jest.fn();
+    const log = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    const platform = {
+      config: { splitNameStrategy: 'Friendly name', virtualControlLabel: 'Virtual Controls' },
+      ha: {
+        callService,
+        hassLabels: new Map([['virtual-controls', { label_id: 'virtual-controls', name: 'Virtual Controls' }]]),
+        hassStates: new Map([[e.entity_id, s]]),
+      },
+      log,
+      registerVirtualDevice,
+    } as any;
+    const entity = { ...e, labels: ['virtual-controls'] } as HassEntity;
+
+    addControlEntity(platform, md, entity, s, commandHandler, subscribeHandler as any);
+
+    const turnOnCallback = registerVirtualDevice.mock.calls[0][2] as VirtualDeviceCallback;
+    await turnOnCallback();
+    await Promise.resolve();
+
+    expect(callService).toHaveBeenCalledWith('media_player', MediaPlayerService.TURN_ON, e.entity_id);
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining('Failed to call turn on service for'));
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining('Error: boom'));
   });
 
   it('registers all command handlers for light domain', () => {

--- a/src/control.entity.test.ts
+++ b/src/control.entity.test.ts
@@ -46,6 +46,9 @@ function createMockMutableDevice(): MutableDevice {
     addClusterServerCompleteFanControl: jest.fn(),
     addVacuum: jest.fn(),
     addSelect: jest.fn(),
+    addOnOff: jest.fn(),
+    addBasicVideoPlayer: jest.fn(),
+    addKeypadInput: jest.fn(),
     addCommandHandler: jest.fn(),
     addSubscribeHandler: jest.fn(),
   } as unknown as MutableDevice;
@@ -65,7 +68,7 @@ describe('addControlEntity', () => {
   };
 
   it('returns undefined for unsupported domain', () => {
-    const [md, e, s] = make('media_player', 'x', {});
+    const [md, e, s] = make('scene', 'x', {});
     expect(addControlEntity(mockPlatform, md, e as any, s as any, commandHandler, subscribeHandler as any)).toBeUndefined();
   });
 
@@ -200,6 +203,26 @@ describe('addControlEntity', () => {
     expect(args[0]).toBe(entity.entity_id);
     expect(args[1]).toEqual(expect.any(String));
     expect(args[2]).toEqual(attributes.options);
+  });
+
+  it('configures remote entities with on/off support', () => {
+    const [md, e, s] = make('remote', 'tv', {});
+
+    const ep = addControlEntity(mockPlatform, md, e as any, s as any, commandHandler, subscribeHandler as any);
+
+    expect(ep).toBe(e.entity_id);
+    expect(md.addOnOff).toHaveBeenCalledWith(e.entity_id, true);
+  });
+
+  it('configures media players with playback and keypad support', () => {
+    const [md, e, s] = make('media_player', 'tv', { supported_features: 0 });
+
+    const ep = addControlEntity(mockPlatform, md, e as any, s as any, commandHandler, subscribeHandler as any);
+
+    expect(ep).toBe(e.entity_id);
+    expect(md.addOnOff).toHaveBeenCalledWith(e.entity_id, true);
+    expect(md.addBasicVideoPlayer).toHaveBeenCalledWith(e.entity_id);
+    expect(md.addKeypadInput).toHaveBeenCalledWith(e.entity_id);
   });
 
   it('registers all command handlers for light domain', () => {

--- a/src/control.entity.test.ts
+++ b/src/control.entity.test.ts
@@ -45,6 +45,7 @@ function createMockMutableDevice(): MutableDevice {
     addClusterServerHeatingCoolingThermostat: jest.fn(),
     addClusterServerCompleteFanControl: jest.fn(),
     addVacuum: jest.fn(),
+    addSelect: jest.fn(),
     addCommandHandler: jest.fn(),
     addSubscribeHandler: jest.fn(),
   } as unknown as MutableDevice;
@@ -176,6 +177,29 @@ describe('addControlEntity', () => {
     const [md2, e2, s2] = make('fan', 'base', { preset_modes: ['low'] });
     addControlEntity(mockPlatform, md2, e2 as any, s2 as any, commandHandler, subscribeHandler as any);
     expect(md2.addDeviceTypes).toHaveBeenCalledWith(e2.entity_id, fanDevice);
+  });
+
+  it.each([
+    {
+      entity: { entity_id: 'select.mode' },
+      attributes: { options: ['Low', 'Medium', 'High', 'Auto'] },
+    },
+    {
+      entity: { entity_id: 'input_select.mode' },
+      attributes: { options: ['Eco', 'Comfort', 'Boost', 'Off'] },
+    },
+  ])('forwards every available option to addSelect for $entity.entity_id', ({ entity, attributes }) => {
+    const md = createMockMutableDevice();
+    const state = { attributes } as HassState;
+
+    addControlEntity(mockPlatform, md, entity as HassEntity, state, commandHandler, subscribeHandler as any);
+
+    expect(md.addSelect).toHaveBeenCalledTimes(1);
+    // @ts-expect-error mock calls on the test double
+    const args = md.addSelect.mock.calls[0];
+    expect(args[0]).toBe(entity.entity_id);
+    expect(args[1]).toEqual(expect.any(String));
+    expect(args[2]).toEqual(attributes.options);
   });
 
   it('registers all command handlers for light domain', () => {

--- a/src/control.entity.ts
+++ b/src/control.entity.ts
@@ -44,6 +44,7 @@ import {
   HomeAssistant,
   HVACMode,
   LightEntityFeature,
+  MediaPlayerEntityFeature,
   UnitOfTemperature,
   VacuumEntityFeature,
 } from './homeAssistant.js';
@@ -198,6 +199,23 @@ export function addControlEntity(
   if (domain === 'select' || domain === 'input_select') {
     platform.log.debug(`= select device ${CYAN}${entity.entity_id}${db} options: ${CYAN}${state.attributes['options']}${db}`);
     mutableDevice.addSelect(endpointName, getEntityName(platform, entity) ?? 'Select an option', state.attributes['options']);
+  }
+
+  // Configure the remote.
+  if (domain === 'remote') {
+    platform.log.debug(`= remote device ${CYAN}${entity.entity_id}${db} state: ${CYAN}${state.state}${db}`);
+    mutableDevice.addOnOff(endpointName, true);
+  }
+
+  // Configure the media_player.
+  if (domain === 'media_player') {
+    platform.log.debug(`= media_player device ${CYAN}${entity.entity_id}${db} state: ${CYAN}${state.state}${db} attrbutes: ${CYAN}${debugStringify(state.attributes)}${db}`);
+    platform.log.debug(
+      `# media_player device ${CYAN}${entity.entity_id}${db} supported_features: ${CYAN}${getFeatureNames(MediaPlayerEntityFeature, state.attributes.supported_features)}${db}`,
+    );
+    mutableDevice.addOnOff(endpointName, true);
+    mutableDevice.addBasicVideoPlayer(endpointName);
+    mutableDevice.addKeypadInput(endpointName);
   }
 
   // Add command handlers

--- a/src/control.entity.ts
+++ b/src/control.entity.ts
@@ -30,7 +30,7 @@ import { ClusterId, getClusterNameById } from 'matterbridge/matter/types';
 import { isValidArray, isValidBoolean, isValidNumber, isValidString } from 'matterbridge/utils';
 
 import { getFeatureNames, hassCommandConverter, hassDomainConverter, hassSubscribeConverter, kelvinToMireds, roundTo, temp } from './converters.js';
-import { getDomain } from './helpers.js';
+import { getDomain, getEntityName } from './helpers.js';
 import {
   ClimateEntityFeature,
   ColorMode,
@@ -192,6 +192,12 @@ export function addControlEntity(
       `# vacuum device ${CYAN}${entity.entity_id}${db} supported_features: ${CYAN}${getFeatureNames(VacuumEntityFeature, state.attributes.supported_features)}${db}`,
     );
     mutableDevice.addVacuum(endpointName);
+  }
+
+  // Configure the select.
+  if (domain === 'select' || domain === 'input_select') {
+    platform.log.debug(`= select device ${CYAN}${entity.entity_id}${db} options: ${CYAN}${state.attributes['options']}${db}`);
+    mutableDevice.addSelect(endpointName, getEntityName(platform, entity) ?? 'Select an option', state.attributes['options']);
   }
 
   // Add command handlers

--- a/src/control.entity.ts
+++ b/src/control.entity.ts
@@ -200,6 +200,16 @@ export function addControlEntity(
   if (domain === 'select' || domain === 'input_select') {
     platform.log.debug(`= select device ${CYAN}${entity.entity_id}${db} options: ${CYAN}${state.attributes['options']}${db}`);
     mutableDevice.addSelect(endpointName, getEntityName(platform, entity) ?? 'Select an option', state.attributes['options']);
+    if (entityHasLabel(platform, entity, platform.config.virtualControlLabel)) {
+      state.attributes['options']?.forEach((option: string) => {
+        platform.log.debug(`***Add select device ${CYAN}${entity.entity_id}${db} virtual control: ${CYAN}${option}${db}`);
+        platform.registerVirtualDevice(`${getEntityName(platform, entity)} ${option}`, 'mounted_switch', async () => {
+          platform.ha.callService(domain, 'select_option', entity.entity_id, { option }).catch((error) => {
+            platform.log.error(`Failed to call select_option service for ${CYAN}${entity.entity_id}${db} with option ${CYAN}${option}${db}: ${error}`);
+          });
+        });
+      });
+    }
   }
 
   // Configure the remote.

--- a/src/control.entity.ts
+++ b/src/control.entity.ts
@@ -30,7 +30,7 @@ import { ClusterId, getClusterNameById } from 'matterbridge/matter/types';
 import { isValidArray, isValidBoolean, isValidNumber, isValidString } from 'matterbridge/utils';
 
 import { getFeatureNames, hassCommandConverter, hassDomainConverter, hassSubscribeConverter, kelvinToMireds, roundTo, temp } from './converters.js';
-import { getDomain, getEntityName } from './helpers.js';
+import { entityHasLabel, getDomain, getEntityName } from './helpers.js';
 import {
   ClimateEntityFeature,
   ColorMode,
@@ -45,6 +45,7 @@ import {
   HVACMode,
   LightEntityFeature,
   MediaPlayerEntityFeature,
+  MediaPlayerService,
   UnitOfTemperature,
   VacuumEntityFeature,
 } from './homeAssistant.js';
@@ -216,6 +217,30 @@ export function addControlEntity(
     mutableDevice.addOnOff(endpointName, true);
     mutableDevice.addBasicVideoPlayer(endpointName);
     mutableDevice.addKeypadInput(endpointName);
+    if (entityHasLabel(platform, entity, platform.config.virtualControlLabel)) {
+      const featuresServices: { feature: MediaPlayerEntityFeature; service: MediaPlayerService; controlName: string }[] = [
+        { feature: MediaPlayerEntityFeature.TURN_ON, service: MediaPlayerService.TURN_ON, controlName: 'Turn ON' },
+        { feature: MediaPlayerEntityFeature.TURN_OFF, service: MediaPlayerService.TURN_OFF, controlName: 'Turn OFF' },
+        { feature: MediaPlayerEntityFeature.PLAY, service: MediaPlayerService.MEDIA_PLAY, controlName: 'Play' },
+        { feature: MediaPlayerEntityFeature.PAUSE, service: MediaPlayerService.MEDIA_PAUSE, controlName: 'Pause' },
+        { feature: MediaPlayerEntityFeature.STOP, service: MediaPlayerService.MEDIA_STOP, controlName: 'Stop' },
+        { feature: MediaPlayerEntityFeature.VOLUME_MUTE, service: MediaPlayerService.VOLUME_MUTE, controlName: 'Mute' },
+        { feature: MediaPlayerEntityFeature.VOLUME_STEP, service: MediaPlayerService.VOLUME_DOWN, controlName: 'Volume Down' },
+        { feature: MediaPlayerEntityFeature.VOLUME_STEP, service: MediaPlayerService.VOLUME_UP, controlName: 'Volume Up' },
+        { feature: MediaPlayerEntityFeature.PREVIOUS_TRACK, service: MediaPlayerService.MEDIA_PREVIOUS_TRACK, controlName: 'Previous Track' },
+        { feature: MediaPlayerEntityFeature.NEXT_TRACK, service: MediaPlayerService.MEDIA_NEXT_TRACK, controlName: 'Next Track' },
+      ];
+      featuresServices.forEach(({ feature, service, controlName }) => {
+        if (state.attributes['supported_features'] && state.attributes['supported_features'] & feature) {
+          platform.log.debug(`***Add media_player device ${CYAN}${entity.entity_id}${db} virtual control:${CYAN}${controlName}${db}`);
+          platform.registerVirtualDevice(`${controlName} ${getEntityName(platform, entity)}`, 'mounted_switch', async () => {
+            platform.ha.callService('media_player', service, entity.entity_id).catch((error) => {
+              platform.log.error(`Failed to call ${controlName.toLowerCase()} service for ${CYAN}${entity.entity_id}${db}: ${error}`);
+            });
+          });
+        }
+      });
+    }
   }
 
   // Add command handlers

--- a/src/converters.test.ts
+++ b/src/converters.test.ts
@@ -25,6 +25,18 @@ import {
 } from './converters.js';
 import { ClimateEntityFeature, ColorMode, FanEntityFeature, HassConfig, HassState, HassUnitSystem, HomeAssistant, HVACMode, UnitOfTemperature } from './homeAssistant.js';
 
+function createSelectState(options: string[]): HassState {
+  return {
+    entity_id: 'select.test_mode',
+    state: options[0] ?? '',
+    last_changed: '',
+    last_reported: '',
+    last_updated: '',
+    attributes: { options } as HassState['attributes'],
+    context: { id: '', parent_id: null, user_id: null },
+  };
+}
+
 describe('HassPlatform converters', () => {
   it('should return the feature names for supported features', () => {
     expect(getFeatureNames(FanEntityFeature, 0)).toEqual([]);
@@ -356,6 +368,12 @@ describe('HassPlatform converters', () => {
             undefined as any,
           ),
         ).toEqual({ hs_color: [142, 20] });
+      }
+      if (converter.converter && converter.command === 'changeToMode' && converter.service === 'select_option') {
+        expect(converter.converter({ newMode: 2 }, undefined as any, createSelectState(['Eco', 'Comfort']))).toEqual({ option: 'Comfort' });
+        expect(converter.converter({}, undefined as any, createSelectState(['Eco', 'Comfort']))).toBeUndefined();
+        expect(converter.converter({ newMode: 3 }, undefined as any, createSelectState(['Eco', 'Comfort']))).toBeUndefined();
+        expect(converter.converter({ newMode: 1 }, undefined as any, createSelectState([]))).toBeUndefined();
       }
     });
   });

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -36,6 +36,7 @@ import {
   humiditySensor,
   lightSensor,
   MatterbridgeEndpointCommands,
+  modeSelect,
   occupancySensor,
   onOffLight,
   onOffOutlet,
@@ -62,6 +63,7 @@ import {
   FormaldehydeConcentrationMeasurement,
   IlluminanceMeasurement,
   LevelControl,
+  ModeSelect,
   NitrogenDioxideConcentrationMeasurement,
   OccupancySensing,
   OnOff,
@@ -343,6 +345,9 @@ export const hassUpdateStateConverter: { domain: string; state: string; clusterI
 
     { domain: 'binary_sensor', state: 'on', clusterId: BooleanState.Cluster.id, attribute: 'stateValue', value: true },
     { domain: 'binary_sensor', state: 'off', clusterId: BooleanState.Cluster.id, attribute: 'stateValue', value: false },
+
+    { domain: 'remote', state: 'on', clusterId: OnOff.Cluster.id, attribute: 'onOff', value: true },
+    { domain: 'remote', state: 'off', clusterId: OnOff.Cluster.id, attribute: 'onOff', value: false },
   ];
 
 /** Update Home Assistant attributes to Matterbridge device attributes */
@@ -415,6 +420,9 @@ export const hassDomainConverter: { domain: string; withAttribute?: string; devi
     { domain: 'vacuum',                                 deviceType: roboticVacuumCleaner,   clusterId: RvcRunMode.Cluster.id },
     { domain: 'vacuum',                                 deviceType: roboticVacuumCleaner,   clusterId: RvcCleanMode.Cluster.id },
     { domain: 'vacuum',                                 deviceType: roboticVacuumCleaner,   clusterId: RvcOperationalState.Cluster.id },
+    { domain: 'remote',                                 deviceType: onOffOutlet,            clusterId: OnOff.Cluster.id },
+    { domain: 'input_select',                           deviceType: modeSelect,             clusterId: ModeSelect.Cluster.id },
+    { domain: 'select',                                 deviceType: modeSelect,             clusterId: ModeSelect.Cluster.id },
     { domain: 'sensor',                                 deviceType: null,                   clusterId: null },
     { domain: 'binary_sensor',                          deviceType: null,                   clusterId: null },
   ];
@@ -517,6 +525,12 @@ export const hassCommandConverter: { command: keyof MatterbridgeEndpointCommands
     { command: 'resume',                  domain: 'vacuum', service: 'start' },
     { command: 'goHome',                  domain: 'vacuum', service: 'return_to_base' },
     { command: 'changeToMode',            domain: 'vacuum', service: 'start' },
+
+    { command: 'on',                      domain: 'remote', service: 'turn_on' },
+    { command: 'off',                     domain: 'remote', service: 'turn_off' },
+
+    { command: 'changeToMode',            domain: 'input_select', service: 'select_option' },
+    { command: 'changeToMode',            domain: 'select', service: 'select_option' },
   ];
 
 /**

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -297,6 +297,31 @@ export function convertHAXYToMatter(xyColor: [number, number]): { currentX: numb
   return { currentX, currentY };
 }
 
+/**
+ * Returns the selected Home Assistant option for a Matter mode change request.
+ *
+ * @param {Record<string, unknown>} request - Matter command payload containing the target mode index.
+ * @param {number} [request.newMode] - One-based mode index received from Matter.
+ * @param {HassState | undefined} state - Current Home Assistant state containing the available options.
+ * @returns {{ option: string } | undefined} The mapped option payload, or undefined when the request is invalid.
+ */
+function getSelectOptionFromMode(request: Record<string, unknown>, state: HassState | undefined): { option: string } | undefined {
+  const options = state?.attributes?.options;
+  const newMode = request['newMode'];
+
+  if (!isValidNumber(newMode, 1)) {
+    return undefined;
+  }
+
+  const optionIndex = newMode - 1;
+
+  if (!isValidArray(options, 1) || !isValidNumber(optionIndex, 0, options.length - 1) || !isValidString(options[optionIndex], 1)) {
+    return undefined;
+  }
+
+  return { option: options[optionIndex] };
+}
+
 /** Update Home Assistant state to Matterbridge device states */
 // prettier-ignore
 export const hassUpdateStateConverter: { domain: string; state: string; clusterId: ClusterId | undefined; attribute: string; value: any }[] = [
@@ -542,8 +567,8 @@ export const hassCommandConverter: { command: keyof MatterbridgeEndpointCommands
     { command: 'on',                      domain: 'remote', service: 'turn_on' },
     { command: 'off',                     domain: 'remote', service: 'turn_off' },
 
-    { command: 'changeToMode',            domain: 'input_select', service: 'select_option' },
-    { command: 'changeToMode',            domain: 'select', service: 'select_option' },
+    { command: 'changeToMode',            domain: 'input_select', service: 'select_option', converter: (request, attributes, state) => { return getSelectOptionFromMode(request, state) } },
+    { command: 'changeToMode',            domain: 'select', service: 'select_option', converter: (request, attributes, state) => { return getSelectOptionFromMode(request, state) }  },
 
     { command: 'on',                      domain: 'media_player', service: 'turn_on' },
     { command: 'off',                     domain: 'media_player', service: 'turn_off' },

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -24,6 +24,7 @@
 
 import {
   airQualitySensor,
+  basicVideoPlayer,
   colorTemperatureLight,
   contactSensor,
   coverDevice,
@@ -63,6 +64,7 @@ import {
   FormaldehydeConcentrationMeasurement,
   IlluminanceMeasurement,
   LevelControl,
+  MediaPlayback,
   ModeSelect,
   NitrogenDioxideConcentrationMeasurement,
   OccupancySensing,
@@ -348,6 +350,16 @@ export const hassUpdateStateConverter: { domain: string; state: string; clusterI
 
     { domain: 'remote', state: 'on', clusterId: OnOff.Cluster.id, attribute: 'onOff', value: true },
     { domain: 'remote', state: 'off', clusterId: OnOff.Cluster.id, attribute: 'onOff', value: false },
+
+    { domain: 'media_player', state: 'on', clusterId: OnOff.Cluster.id, attribute: 'onOff', value: true },
+    { domain: 'media_player', state: 'off', clusterId: OnOff.Cluster.id, attribute: 'onOff', value: false },
+    { domain: 'media_player', state: 'playing', clusterId: MediaPlayback.Cluster.id, attribute: 'currentState', value: MediaPlayback.PlaybackState.Playing },
+    { domain: 'media_player', state: 'paused', clusterId: MediaPlayback.Cluster.id, attribute: 'currentState', value: MediaPlayback.PlaybackState.Paused },
+    { domain: 'media_player', state: 'idle', clusterId: MediaPlayback.Cluster.id, attribute: 'currentState', value: MediaPlayback.PlaybackState.NotPlaying },
+    { domain: 'media_player', state: 'standby', clusterId: MediaPlayback.Cluster.id, attribute: 'currentState', value: MediaPlayback.PlaybackState.NotPlaying },
+    { domain: 'media_player', state: 'buffering', clusterId: MediaPlayback.Cluster.id, attribute: 'currentState', value: MediaPlayback.PlaybackState.Buffering },
+    { domain: 'media_player', state: 'on', clusterId: MediaPlayback.Cluster.id, attribute: 'currentState', value: MediaPlayback.PlaybackState.Playing },
+    { domain: 'media_player', state: 'off', clusterId: MediaPlayback.Cluster.id, attribute: 'currentState', value: MediaPlayback.PlaybackState.NotPlaying },
   ];
 
 /** Update Home Assistant attributes to Matterbridge device attributes */
@@ -423,6 +435,7 @@ export const hassDomainConverter: { domain: string; withAttribute?: string; devi
     { domain: 'remote',                                 deviceType: onOffOutlet,            clusterId: OnOff.Cluster.id },
     { domain: 'input_select',                           deviceType: modeSelect,             clusterId: ModeSelect.Cluster.id },
     { domain: 'select',                                 deviceType: modeSelect,             clusterId: ModeSelect.Cluster.id },
+    { domain: 'media_player',                           deviceType: basicVideoPlayer,       clusterId: MediaPlayback.Cluster.id },
     { domain: 'sensor',                                 deviceType: null,                   clusterId: null },
     { domain: 'binary_sensor',                          deviceType: null,                   clusterId: null },
   ];
@@ -531,6 +544,14 @@ export const hassCommandConverter: { command: keyof MatterbridgeEndpointCommands
 
     { command: 'changeToMode',            domain: 'input_select', service: 'select_option' },
     { command: 'changeToMode',            domain: 'select', service: 'select_option' },
+
+    { command: 'on',                      domain: 'media_player', service: 'turn_on' },
+    { command: 'off',                     domain: 'media_player', service: 'turn_off' },
+    { command: 'play',                    domain: 'media_player', service: 'media_play' },
+    { command: 'pause',                   domain: 'media_player', service: 'media_pause' },
+    { command: 'stop',                    domain: 'media_player', service: 'media_stop' },
+    { command: 'previous',                domain: 'media_player', service: 'media_previous_track' },
+    { command: 'next',                    domain: 'media_player', service: 'media_next_track' },
   ];
 
 /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -435,7 +435,12 @@ export function generateEntity(
  * @param {Record<string, string | number | boolean | null>} attributes - The related state attributes.
  * @returns {HassState} - A Home Assistant state.
  */
-export function generateState(ha: HomeAssistant, entity: HassEntity, state: string = 'unknown', attributes: Record<string, string | number | boolean | null> = {}): HassState {
+export function generateState(
+  ha: HomeAssistant,
+  entity: HassEntity,
+  state: string = 'unknown',
+  attributes: Record<string, string | number | boolean | null | object> = {},
+): HassState {
   const timestamp = new Date().toISOString();
   const entityFriendlyName = entity.original_name ?? entity.name ?? undefined;
   const deviceName = entity.device_id ? (ha.hassDevices.get(entity.device_id)?.name_by_user ?? ha.hassDevices.get(entity.device_id)?.name ?? undefined) : undefined;

--- a/src/homeAssistant.ts
+++ b/src/homeAssistant.ts
@@ -206,7 +206,9 @@ export interface HassStateMediaPlayerAttributes {
   is_volume_muted?: boolean | null;
   media_content_id?: string | null;
   media_content_type?: MediaType | string | null;
+  announce?: boolean | null;
   media_duration?: number | null; // Duration in seconds.
+  enqueue?: MediaPlayerEnqueue | boolean | null;
   media_position?: number | null; // Position in seconds.
   media_position_updated_at?: string | null; // ISO timestamp.
   media_image_url?: string | null;
@@ -226,6 +228,7 @@ export interface HassStateMediaPlayerAttributes {
   sound_mode?: string | null;
   sound_mode_list?: string[] | null;
   seek_position?: number | null;
+  search_query?: string | null;
   entity_picture_local?: string | null;
   media_filter_classes?: string[] | null;
   extra?: Record<string, HomeAssistantPrimitive> | null;
@@ -270,11 +273,13 @@ export enum MediaPlayerAttribute {
   INPUT_SOURCE_LIST = 'source_list',
   MEDIA_ALBUM_ARTIST = 'media_album_artist',
   MEDIA_ALBUM_NAME = 'media_album_name',
+  MEDIA_ANNOUNCE = 'announce',
   MEDIA_ARTIST = 'media_artist',
   MEDIA_CHANNEL = 'media_channel',
   MEDIA_CONTENT_ID = 'media_content_id',
   MEDIA_CONTENT_TYPE = 'media_content_type',
   MEDIA_DURATION = 'media_duration',
+  MEDIA_ENQUEUE = 'enqueue',
   MEDIA_EPISODE = 'media_episode',
   MEDIA_EXTRA = 'extra',
   MEDIA_FILTER_CLASSES = 'media_filter_classes',
@@ -284,6 +289,7 @@ export enum MediaPlayerAttribute {
   MEDIA_POSITION = 'media_position',
   MEDIA_POSITION_UPDATED_AT = 'media_position_updated_at',
   MEDIA_REPEAT = 'repeat',
+  MEDIA_SEARCH_QUERY = 'search_query',
   MEDIA_SEASON = 'media_season',
   MEDIA_SEEK_POSITION = 'seek_position',
   MEDIA_SERIES_TITLE = 'media_series_title',

--- a/src/module.auto.test.ts
+++ b/src/module.auto.test.ts
@@ -742,13 +742,17 @@ describe('Matterbridge ' + NAME, () => {
     const device = generateDevice(haPlatform.ha, 'TV Device');
     const remoteIndividualEntity = generateEntity(haPlatform.ha, 'Individual remote', 'remote');
     const remoteDeviceEntity = generateEntity(haPlatform.ha, 'Device remote entity', 'remote', device);
+    const mediaplayerDeviceEntity = generateEntity(haPlatform.ha, 'Device media player entity', 'media_player', device);
     const remoteSplitEntity = generateEntity(haPlatform.ha, 'Split remote entity', 'remote', device);
     generateState(haPlatform.ha, remoteIndividualEntity, 'on');
     generateState(haPlatform.ha, remoteDeviceEntity, 'on');
+    generateState(haPlatform.ha, mediaplayerDeviceEntity, 'on', { supported_features: 448439 });
     generateState(haPlatform.ha, remoteSplitEntity, 'on');
 
     haPlatform.config.splitEntities = [remoteSplitEntity.entity_id];
     haPlatform.config.controllerStrategy = 'Merge';
+
+    // await setDebug(true);
 
     await haPlatform.onStart('Test reason');
     expect(loggerInfoSpy).toHaveBeenCalledWith(`Starting platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);
@@ -761,15 +765,17 @@ describe('Matterbridge ' + NAME, () => {
     expect(haPlatform.matterbridgeDevices.has(remoteIndividualEntity.entity_id)).toBe(true);
     expect(haPlatform.matterbridgeDevices.has(device.id)).toBe(true);
     expect(haPlatform.matterbridgeDevices.has(remoteDeviceEntity.entity_id)).toBe(false);
+    expect(haPlatform.matterbridgeDevices.has(mediaplayerDeviceEntity.entity_id)).toBe(false);
     expect(haPlatform.matterbridgeDevices.has(remoteSplitEntity.entity_id)).toBe(true);
-    expect(haPlatform.endpointNames.size).toBe(3);
+    expect(haPlatform.endpointNames.size).toBe(4);
     expect(haPlatform.endpointNames.get(remoteIndividualEntity.entity_id)).toBe('');
-    expect(haPlatform.endpointNames.get(remoteDeviceEntity.entity_id)).toBe('');
+    expect(haPlatform.endpointNames.get(remoteDeviceEntity.entity_id)).toBe('remote.device_remote_entity');
+    expect(haPlatform.endpointNames.get(mediaplayerDeviceEntity.entity_id)).toBe('media_player.device_media_player_entity');
     expect(haPlatform.endpointNames.get(remoteSplitEntity.entity_id)).toBe('');
     expect(aggregator.parts.size).toBe(3);
     const endpoint = haPlatform.matterbridgeDevices.get(device.id);
     expect(endpoint).toBeDefined();
-    expect(endpoint?.getChildEndpoints().length).toBe(0);
+    expect(endpoint?.getChildEndpoints().length).toBe(2);
 
     jest.clearAllMocks();
     haPlatform.filterMessages.length = 0;
@@ -790,8 +796,6 @@ describe('Matterbridge ' + NAME, () => {
 
     haPlatform.config.splitEntities = [selectSplitEntity.entity_id];
     haPlatform.config.controllerStrategy = 'Merge';
-
-    await setDebug(true);
 
     await haPlatform.onStart('Test reason');
     expect(loggerInfoSpy).toHaveBeenCalledWith(`Starting platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);

--- a/src/module.auto.test.ts
+++ b/src/module.auto.test.ts
@@ -2,11 +2,11 @@
 
 /* eslint-disable no-console */
 
-const MATTER_PORT = 6200;
 const NAME = 'PlatformAuto';
-const HOMEDIR = path.join('.cache', 'jest', NAME);
+const MATTER_PORT = 6200;
 const MATTER_CREATE_ONLY = true;
 const MATTER_PAUSE = 10;
+const HOMEDIR = path.join('.cache', 'jest', NAME);
 
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
@@ -16,10 +16,12 @@ import { MatterbridgeEndpoint, onOffMountedSwitch, onOffOutlet } from 'matterbri
 import {
   addDevice,
   aggregator,
+  createServerNode,
   createTestEnvironment,
   deleteDevice,
   destroyTestEnvironment,
   flushAsync,
+  flushServerNode,
   log,
   loggerDebugSpy,
   loggerErrorSpy,
@@ -112,7 +114,7 @@ describe('Matterbridge ' + NAME, () => {
       osRelease: 'xx.xx.xx.xx.xx.xx',
       nodeVersion: '22.1.10',
     },
-    matterbridgeVersion: '3.7.3',
+    matterbridgeVersion: '3.7.5',
     log,
     addBridgedEndpoint: jest.fn(async (pluginName: string, device: MatterbridgeEndpoint) => {
       await addDevice(aggregator, device, MATTER_PAUSE);
@@ -139,9 +141,11 @@ describe('Matterbridge ' + NAME, () => {
 
   beforeAll(async () => {
     // Setup the Matter test environment
-    createTestEnvironment(NAME, MATTER_CREATE_ONLY);
+    await createTestEnvironment();
+    // Create the server node and aggregator
+    await createServerNode(MATTER_PORT);
     // Start the server node and aggregator
-    await startServerNode(NAME, MATTER_PORT, undefined, MATTER_CREATE_ONLY);
+    if (!MATTER_CREATE_ONLY) await startServerNode();
   });
 
   beforeEach(async () => {
@@ -152,15 +156,15 @@ describe('Matterbridge ' + NAME, () => {
   afterEach(async () => {
     // Clean up after each test
     await cleanup();
-    await flushAsync(undefined, undefined, MATTER_PAUSE);
     await setDebug(false);
   });
 
   afterAll(async () => {
-    // Stop the server node
-    await stopServerNode(server, MATTER_CREATE_ONLY);
+    // Stop or flush the server node depending on the create-only mode
+    if (MATTER_CREATE_ONLY) await flushServerNode();
+    else await stopServerNode();
     // Destroy the Matter test environment
-    await destroyTestEnvironment(MATTER_CREATE_ONLY);
+    await destroyTestEnvironment();
 
     // Restore all mocks
     jest.restoreAllMocks();
@@ -221,7 +225,7 @@ describe('Matterbridge ' + NAME, () => {
     mockConfig.unregisterOnShutdown = false;
   }
 
-  it('should initialize the HomeAssistantPlatform', async () => {
+  it('should initialize the HomeAssistantPlatform (mandatory)', async () => {
     haPlatform = new HomeAssistantPlatform(mockMatterbridge, log, mockConfig);
     expect(haPlatform).toBeDefined();
     expect(haPlatform.matterbridgeDevices.size).toBe(0);
@@ -240,8 +244,8 @@ describe('Matterbridge ' + NAME, () => {
     expect(loggerInfoSpy).toHaveBeenCalledWith(`Initialized platform: ${CYAN}${haPlatform.config.name}${nf} version: ${CYAN}${haPlatform.config.version}${rs}`);
     haPlatform.haSubscriptionId = 1;
     haPlatform.ha.connected = true; // Simulate a connected Home Assistant instance
-    haPlatform.ha.hassConfig = {} as HassConfig; // Simulate a Home Assistant configuration
-    haPlatform.ha.hassServices = {} as HassServices; // Simulate a Home Assistant services
+    haPlatform.ha.hassConfig = {} as HassConfig; // Simulate Home Assistant configuration
+    haPlatform.ha.hassServices = {} as HassServices; // Simulate Home Assistant services
   });
 
   it('should call onStart and not register an individual entity if the domain is blacklisted', async () => {
@@ -790,7 +794,7 @@ describe('Matterbridge ' + NAME, () => {
     expect(endpoint?.getChildEndpoints().length).toBe(1);
   });
 
-  it('should call onShutdown and unregister', async () => {
+  it('should call onShutdown and unregister (mandatory)', async () => {
     mockConfig.unregisterOnShutdown = true;
     await haPlatform.onShutdown('Test reason');
     expect(loggerInfoSpy).toHaveBeenCalledWith(`Shutting down platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);

--- a/src/module.auto.test.ts
+++ b/src/module.auto.test.ts
@@ -15,6 +15,7 @@ import { jest } from '@jest/globals';
 import { MatterbridgeEndpoint, onOffMountedSwitch, onOffOutlet } from 'matterbridge';
 import {
   addDevice,
+  addVirtualEndpointMatterbridgeSpy,
   aggregator,
   createServerNode,
   createTestEnvironment,
@@ -736,13 +737,21 @@ describe('Matterbridge ' + NAME, () => {
     const endpoint = haPlatform.matterbridgeDevices.get(device.id);
     expect(endpoint).toBeDefined();
     expect(endpoint?.getChildEndpoints().length).toBe(0);
+
+    jest.clearAllMocks();
+    haPlatform.filterMessages.length = 0;
+    await haPlatform.onConfigure();
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
+    expect(loggerErrorSpy).not.toHaveBeenCalled();
+    expect(loggerFatalSpy).not.toHaveBeenCalled();
   });
 
-  it('should call onStart and register a remote individual entity, a device with two remote entities, one normal and one split with Merge strategy', async () => {
+  it('should call onStart and register a remote individual entity, a media_player device with two remote entities, one normal and one split with Merge strategy', async () => {
+    const virtualLabel = generateLabel(haPlatform.ha, 'Virtual Label');
     const device = generateDevice(haPlatform.ha, 'TV Device');
     const remoteIndividualEntity = generateEntity(haPlatform.ha, 'Individual remote', 'remote');
     const remoteDeviceEntity = generateEntity(haPlatform.ha, 'Device remote entity', 'remote', device);
-    const mediaplayerDeviceEntity = generateEntity(haPlatform.ha, 'Device media player entity', 'media_player', device);
+    const mediaplayerDeviceEntity = generateEntity(haPlatform.ha, 'Device media player entity', 'media_player', device, null, [virtualLabel.label_id]);
     const remoteSplitEntity = generateEntity(haPlatform.ha, 'Split remote entity', 'remote', device);
     generateState(haPlatform.ha, remoteIndividualEntity, 'on');
     generateState(haPlatform.ha, remoteDeviceEntity, 'on');
@@ -750,6 +759,7 @@ describe('Matterbridge ' + NAME, () => {
     generateState(haPlatform.ha, remoteSplitEntity, 'on');
 
     haPlatform.config.splitEntities = [remoteSplitEntity.entity_id];
+    haPlatform.config.virtualControlLabel = virtualLabel.name;
     haPlatform.config.controllerStrategy = 'Merge';
 
     // await setDebug(true);
@@ -760,6 +770,7 @@ describe('Matterbridge ' + NAME, () => {
     expect(loggerDebugSpy).toHaveBeenCalledWith(`Registering device ${dn}${device.name}${db}...`);
     expect(loggerDebugSpy).toHaveBeenCalledWith(`Registering device ${dn}${remoteSplitEntity.original_name}${db}...`);
     expect(loggerInfoSpy).toHaveBeenCalledWith(`Started platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);
+    expect(mockMatterbridge.addVirtualEndpoint).toHaveBeenCalledTimes(9);
     expect(mockMatterbridge.addBridgedEndpoint).toHaveBeenCalledTimes(3);
     expect(haPlatform.matterbridgeDevices.size).toBe(3);
     expect(haPlatform.matterbridgeDevices.has(remoteIndividualEntity.entity_id)).toBe(true);
@@ -772,7 +783,7 @@ describe('Matterbridge ' + NAME, () => {
     expect(haPlatform.endpointNames.get(remoteDeviceEntity.entity_id)).toBe('remote.device_remote_entity');
     expect(haPlatform.endpointNames.get(mediaplayerDeviceEntity.entity_id)).toBe('media_player.device_media_player_entity');
     expect(haPlatform.endpointNames.get(remoteSplitEntity.entity_id)).toBe('');
-    expect(aggregator.parts.size).toBe(3);
+    expect(aggregator.parts.size).toBe(12);
     const endpoint = haPlatform.matterbridgeDevices.get(device.id);
     expect(endpoint).toBeDefined();
     expect(endpoint?.getChildEndpoints().length).toBe(2);
@@ -786,15 +797,17 @@ describe('Matterbridge ' + NAME, () => {
   });
 
   it('should call onStart and register a input_select individual entity, a device with two remote entities, one normal and one split with Merge strategy', async () => {
+    const virtualLabel = generateLabel(haPlatform.ha, 'Virtual Label');
     const device = generateDevice(haPlatform.ha, 'Select Device');
-    const inputSelectIndividualEntity = generateEntity(haPlatform.ha, 'Individual input_select', 'input_select');
-    const selectDeviceEntity = generateEntity(haPlatform.ha, 'Device select entity', 'select', device);
-    const selectSplitEntity = generateEntity(haPlatform.ha, 'Split select entity', 'select', device);
+    const inputSelectIndividualEntity = generateEntity(haPlatform.ha, 'Individual input_select', 'input_select', null, null, [virtualLabel.label_id]);
+    const selectDeviceEntity = generateEntity(haPlatform.ha, 'Device select entity', 'select', device, null, [virtualLabel.label_id]);
+    const selectSplitEntity = generateEntity(haPlatform.ha, 'Split select entity', 'select', device, null, [virtualLabel.label_id]);
     generateState(haPlatform.ha, inputSelectIndividualEntity, 'Led On', { options: ['Led On', 'Led Off'], friendly_name: 'Individual input_select Led' });
     generateState(haPlatform.ha, selectDeviceEntity, 'Led Off', { options: ['Led On', 'Led Off'], friendly_name: 'Device select entity Led' });
     generateState(haPlatform.ha, selectSplitEntity, 'invalid', { options: ['Led On', 'Led Off'], friendly_name: 'Split select entity Led' });
 
     haPlatform.config.splitEntities = [selectSplitEntity.entity_id];
+    haPlatform.config.virtualControlLabel = virtualLabel.name;
     haPlatform.config.controllerStrategy = 'Merge';
 
     await haPlatform.onStart('Test reason');
@@ -803,6 +816,7 @@ describe('Matterbridge ' + NAME, () => {
     expect(loggerDebugSpy).toHaveBeenCalledWith(`Registering device ${dn}${device.name}${db}...`);
     expect(loggerDebugSpy).toHaveBeenCalledWith(`Registering device ${dn}${selectSplitEntity.original_name}${db}...`);
     expect(loggerInfoSpy).toHaveBeenCalledWith(`Started platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);
+    expect(mockMatterbridge.addVirtualEndpoint).toHaveBeenCalledTimes(6);
     expect(mockMatterbridge.addBridgedEndpoint).toHaveBeenCalledTimes(3);
     expect(addSelectSpy).toHaveBeenCalledTimes(3);
     expect(haPlatform.matterbridgeDevices.size).toBe(3);
@@ -814,7 +828,7 @@ describe('Matterbridge ' + NAME, () => {
     expect(haPlatform.endpointNames.get(inputSelectIndividualEntity.entity_id)).toBe('');
     expect(haPlatform.endpointNames.get(selectDeviceEntity.entity_id)).toBe('');
     expect(haPlatform.endpointNames.get(selectSplitEntity.entity_id)).toBe('');
-    expect(aggregator.parts.size).toBe(3);
+    expect(aggregator.parts.size).toBe(9);
     const endpoint = haPlatform.matterbridgeDevices.get(device.id);
     expect(endpoint).toBeDefined();
     expect(endpoint?.getChildEndpoints().length).toBe(0);

--- a/src/module.auto.test.ts
+++ b/src/module.auto.test.ts
@@ -27,6 +27,7 @@ import {
   loggerErrorSpy,
   loggerFatalSpy,
   loggerInfoSpy,
+  loggerNoticeSpy,
   loggerWarnSpy,
   server,
   setDebug,
@@ -96,6 +97,8 @@ const addClusterServerColorControlSpy = jest.spyOn(MutableDevice.prototype, 'add
 const addClusterServerAutoModeThermostatSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerAutoModeThermostat');
 const addClusterServerHeatingThermostatSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerHeatingThermostat');
 const addClusterServerCoolingThermostatSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerCoolingThermostat');
+const addVacuumSpy = jest.spyOn(MutableDevice.prototype, 'addVacuum');
+const addSelectSpy = jest.spyOn(MutableDevice.prototype, 'addSelect');
 
 MatterbridgeEndpoint.logLevel = LogLevel.DEBUG; // Set the log level for MatterbridgeEndpoint to DEBUG
 
@@ -117,14 +120,14 @@ describe('Matterbridge ' + NAME, () => {
     matterbridgeVersion: '3.7.5',
     log,
     addBridgedEndpoint: jest.fn(async (pluginName: string, device: MatterbridgeEndpoint) => {
-      await addDevice(aggregator, device, MATTER_PAUSE);
+      await addDevice(aggregator, device, 1, 0);
     }),
     removeBridgedEndpoint: jest.fn(async (pluginName: string, device: MatterbridgeEndpoint) => {
-      await deleteDevice(aggregator, device, MATTER_PAUSE);
+      await deleteDevice(aggregator, device, 1, 0);
     }),
     removeAllBridgedEndpoints: jest.fn(async (pluginName: string) => {
       for (const device of aggregator.parts) {
-        await deleteDevice(aggregator, device, MATTER_PAUSE);
+        await deleteDevice(aggregator, device, 1, 0);
       }
     }),
     addVirtualEndpoint: jest.fn(async (pluginName: string, name: string, type: 'light' | 'outlet' | 'switch' | 'mounted_switch', callback: () => Promise<void>) => {
@@ -132,7 +135,7 @@ describe('Matterbridge ' + NAME, () => {
       const device = new MatterbridgeEndpoint([onOffMountedSwitch, onOffOutlet], { id: name.replaceAll(' ', '') + ':' + type })
         .createDefaultBridgedDeviceBasicInformationClusterServer(name, createUniqueId(), VendorId(0xfff1), 'Matterbridge', 'Matterbridge Virtual Device')
         .addRequiredClusterServers();
-      await addDevice(aggregator, device, MATTER_PAUSE);
+      await addDevice(aggregator, device, 1, 0);
     }),
   } as any;
 
@@ -733,6 +736,91 @@ describe('Matterbridge ' + NAME, () => {
     const endpoint = haPlatform.matterbridgeDevices.get(device.id);
     expect(endpoint).toBeDefined();
     expect(endpoint?.getChildEndpoints().length).toBe(0);
+  });
+
+  it('should call onStart and register a remote individual entity, a device with two remote entities, one normal and one split with Merge strategy', async () => {
+    const device = generateDevice(haPlatform.ha, 'TV Device');
+    const remoteIndividualEntity = generateEntity(haPlatform.ha, 'Individual remote', 'remote');
+    const remoteDeviceEntity = generateEntity(haPlatform.ha, 'Device remote entity', 'remote', device);
+    const remoteSplitEntity = generateEntity(haPlatform.ha, 'Split remote entity', 'remote', device);
+    generateState(haPlatform.ha, remoteIndividualEntity, 'on');
+    generateState(haPlatform.ha, remoteDeviceEntity, 'on');
+    generateState(haPlatform.ha, remoteSplitEntity, 'on');
+
+    haPlatform.config.splitEntities = [remoteSplitEntity.entity_id];
+    haPlatform.config.controllerStrategy = 'Merge';
+
+    await haPlatform.onStart('Test reason');
+    expect(loggerInfoSpy).toHaveBeenCalledWith(`Starting platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);
+    expect(loggerDebugSpy).toHaveBeenCalledWith(`Registering device ${dn}${remoteIndividualEntity.original_name}${db}...`);
+    expect(loggerDebugSpy).toHaveBeenCalledWith(`Registering device ${dn}${device.name}${db}...`);
+    expect(loggerDebugSpy).toHaveBeenCalledWith(`Registering device ${dn}${remoteSplitEntity.original_name}${db}...`);
+    expect(loggerInfoSpy).toHaveBeenCalledWith(`Started platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);
+    expect(mockMatterbridge.addBridgedEndpoint).toHaveBeenCalledTimes(3);
+    expect(haPlatform.matterbridgeDevices.size).toBe(3);
+    expect(haPlatform.matterbridgeDevices.has(remoteIndividualEntity.entity_id)).toBe(true);
+    expect(haPlatform.matterbridgeDevices.has(device.id)).toBe(true);
+    expect(haPlatform.matterbridgeDevices.has(remoteDeviceEntity.entity_id)).toBe(false);
+    expect(haPlatform.matterbridgeDevices.has(remoteSplitEntity.entity_id)).toBe(true);
+    expect(haPlatform.endpointNames.size).toBe(3);
+    expect(haPlatform.endpointNames.get(remoteIndividualEntity.entity_id)).toBe('');
+    expect(haPlatform.endpointNames.get(remoteDeviceEntity.entity_id)).toBe('');
+    expect(haPlatform.endpointNames.get(remoteSplitEntity.entity_id)).toBe('');
+    expect(aggregator.parts.size).toBe(3);
+    const endpoint = haPlatform.matterbridgeDevices.get(device.id);
+    expect(endpoint).toBeDefined();
+    expect(endpoint?.getChildEndpoints().length).toBe(0);
+
+    jest.clearAllMocks();
+    haPlatform.filterMessages.length = 0;
+    await haPlatform.onConfigure();
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
+    expect(loggerErrorSpy).not.toHaveBeenCalled();
+    expect(loggerFatalSpy).not.toHaveBeenCalled();
+  });
+
+  it('should call onStart and register a input_select individual entity, a device with two remote entities, one normal and one split with Merge strategy', async () => {
+    const device = generateDevice(haPlatform.ha, 'Select Device');
+    const inputSelectIndividualEntity = generateEntity(haPlatform.ha, 'Individual input_select', 'input_select');
+    const selectDeviceEntity = generateEntity(haPlatform.ha, 'Device select entity', 'select', device);
+    const selectSplitEntity = generateEntity(haPlatform.ha, 'Split select entity', 'select', device);
+    generateState(haPlatform.ha, inputSelectIndividualEntity, 'Led On', { options: ['Led On', 'Led Off'], friendly_name: 'Individual input_select Led' });
+    generateState(haPlatform.ha, selectDeviceEntity, 'Led Off', { options: ['Led On', 'Led Off'], friendly_name: 'Device select entity Led' });
+    generateState(haPlatform.ha, selectSplitEntity, 'invalid', { options: ['Led On', 'Led Off'], friendly_name: 'Split select entity Led' });
+
+    haPlatform.config.splitEntities = [selectSplitEntity.entity_id];
+    haPlatform.config.controllerStrategy = 'Merge';
+
+    await setDebug(true);
+
+    await haPlatform.onStart('Test reason');
+    expect(loggerInfoSpy).toHaveBeenCalledWith(`Starting platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);
+    expect(loggerDebugSpy).toHaveBeenCalledWith(`Registering device ${dn}${inputSelectIndividualEntity.original_name}${db}...`);
+    expect(loggerDebugSpy).toHaveBeenCalledWith(`Registering device ${dn}${device.name}${db}...`);
+    expect(loggerDebugSpy).toHaveBeenCalledWith(`Registering device ${dn}${selectSplitEntity.original_name}${db}...`);
+    expect(loggerInfoSpy).toHaveBeenCalledWith(`Started platform ${idn}${mockConfig.name}${rs}${nf}: Test reason`);
+    expect(mockMatterbridge.addBridgedEndpoint).toHaveBeenCalledTimes(3);
+    expect(addSelectSpy).toHaveBeenCalledTimes(3);
+    expect(haPlatform.matterbridgeDevices.size).toBe(3);
+    expect(haPlatform.matterbridgeDevices.has(inputSelectIndividualEntity.entity_id)).toBe(true);
+    expect(haPlatform.matterbridgeDevices.has(device.id)).toBe(true);
+    expect(haPlatform.matterbridgeDevices.has(selectDeviceEntity.entity_id)).toBe(false);
+    expect(haPlatform.matterbridgeDevices.has(selectSplitEntity.entity_id)).toBe(true);
+    expect(haPlatform.endpointNames.size).toBe(3);
+    expect(haPlatform.endpointNames.get(inputSelectIndividualEntity.entity_id)).toBe('');
+    expect(haPlatform.endpointNames.get(selectDeviceEntity.entity_id)).toBe('');
+    expect(haPlatform.endpointNames.get(selectSplitEntity.entity_id)).toBe('');
+    expect(aggregator.parts.size).toBe(3);
+    const endpoint = haPlatform.matterbridgeDevices.get(device.id);
+    expect(endpoint).toBeDefined();
+    expect(endpoint?.getChildEndpoints().length).toBe(0);
+
+    jest.clearAllMocks();
+    haPlatform.filterMessages.length = 0;
+    await haPlatform.onConfigure();
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
+    expect(loggerErrorSpy).not.toHaveBeenCalled();
+    expect(loggerFatalSpy).not.toHaveBeenCalled();
   });
 
   it('should call onStart and not register an individual entity, a device with two entities, one normal and one split with discardHiddenEntities enabled', async () => {

--- a/src/module.matter.test.ts
+++ b/src/module.matter.test.ts
@@ -13,6 +13,7 @@ import path from 'node:path';
 import { jest } from '@jest/globals';
 import { invokeBehaviorCommand, invokeSubscribeHandler, MatterbridgeEndpoint, occupancySensor } from 'matterbridge';
 import {
+  addDevice,
   aggregator,
   createServerNode,
   createTestEnvironment,
@@ -137,6 +138,8 @@ const addClusterServerColorControlSpy = jest.spyOn(MutableDevice.prototype, 'add
 const addClusterServerAutoModeThermostatSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerAutoModeThermostat');
 const addClusterServerHeatingThermostatSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerHeatingThermostat');
 const addClusterServerCoolingThermostatSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerCoolingThermostat');
+const addVacuumSpy = jest.spyOn(MutableDevice.prototype, 'addVacuum');
+const addSelectSpy = jest.spyOn(MutableDevice.prototype, 'addSelect');
 
 MatterbridgeEndpoint.logLevel = LogLevel.DEBUG; // Set the log level for MatterbridgeEndpoint to DEBUG
 
@@ -157,11 +160,10 @@ describe('Matterbridge ' + NAME, () => {
       osRelease: 'xx.xx.xx.xx.xx.xx',
       nodeVersion: '22.1.10',
     },
-    matterbridgeVersion: '3.7.0',
+    matterbridgeVersion: '3.7.5',
     log,
     addBridgedEndpoint: jest.fn(async (pluginName: string, device: MatterbridgeEndpoint) => {
-      await aggregator.add(device);
-      await flushAsync(undefined, undefined, 10);
+      await addDevice(aggregator, device, 1, 0);
     }),
     removeBridgedEndpoint: jest.fn(async (pluginName: string, device: MatterbridgeEndpoint) => {}),
     removeAllBridgedEndpoints: jest.fn(async (pluginName: string) => {}),

--- a/src/module.matter.test.ts
+++ b/src/module.matter.test.ts
@@ -2,8 +2,9 @@
 
 /* eslint-disable no-console */
 
-const MATTER_PORT = 6100;
 const NAME = 'PlatformMatter';
+const MATTER_PORT = 6100;
+const MATTER_CREATE_ONLY = true;
 const HOMEDIR = path.join('.cache', 'jest', NAME);
 
 import { readFileSync } from 'node:fs';
@@ -13,9 +14,17 @@ import { jest } from '@jest/globals';
 import { invokeBehaviorCommand, invokeSubscribeHandler, MatterbridgeEndpoint, occupancySensor } from 'matterbridge';
 import {
   aggregator,
+  createServerNode,
   createTestEnvironment,
   destroyTestEnvironment,
   flushAsync,
+  flushServerNode,
+  getMoveToColorRequest,
+  getMoveToColorTemperatureRequest,
+  getMoveToHueAndSaturationRequest,
+  getMoveToHueRequest,
+  getMoveToLevelRequest,
+  getMoveToSaturationRequest,
   log,
   loggerDebugSpy,
   loggerErrorSpy,
@@ -129,70 +138,6 @@ const addClusterServerAutoModeThermostatSpy = jest.spyOn(MutableDevice.prototype
 const addClusterServerHeatingThermostatSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerHeatingThermostat');
 const addClusterServerCoolingThermostatSpy = jest.spyOn(MutableDevice.prototype, 'addClusterServerCoolingThermostat');
 
-// Remove these helpers and use matterbridge when you require a new minor version
-const getMoveToLevelRequest = (level: number, transitionTime: number, executeIfOff: boolean) => {
-  const request: LevelControl.MoveToLevelRequest = {
-    level,
-    transitionTime,
-    optionsMask: { executeIfOff, coupleColorTempToLevel: false },
-    optionsOverride: { executeIfOff, coupleColorTempToLevel: false },
-  };
-  return request;
-};
-
-const getMoveToColorTemperatureRequest = (colorTemperatureMireds: number, transitionTime: number, executeIfOff: boolean) => {
-  const request: ColorControl.MoveToColorTemperatureRequest = {
-    colorTemperatureMireds,
-    transitionTime,
-    optionsMask: { executeIfOff },
-    optionsOverride: { executeIfOff },
-  };
-  return request;
-};
-
-const getMoveToHueRequest = (hue: number, transitionTime: number, executeIfOff: boolean) => {
-  const request: ColorControl.MoveToHueRequest = {
-    hue,
-    transitionTime,
-    direction: ColorControl.Direction.Shortest,
-    optionsMask: { executeIfOff },
-    optionsOverride: { executeIfOff },
-  };
-  return request;
-};
-
-const getMoveToSaturationRequest = (saturation: number, transitionTime: number, executeIfOff: boolean) => {
-  const request: ColorControl.MoveToSaturationRequest = {
-    saturation,
-    transitionTime,
-    optionsMask: { executeIfOff },
-    optionsOverride: { executeIfOff },
-  };
-  return request;
-};
-
-const getMoveToHueAndSaturationRequest = (hue: number, saturation: number, transitionTime: number, executeIfOff: boolean) => {
-  const request: ColorControl.MoveToHueAndSaturationRequest = {
-    hue,
-    saturation,
-    transitionTime,
-    optionsMask: { executeIfOff },
-    optionsOverride: { executeIfOff },
-  };
-  return request;
-};
-
-const getMoveToColorRequest = (colorX: number, colorY: number, transitionTime: number, executeIfOff: boolean) => {
-  const request: ColorControl.MoveToColorRequest = {
-    colorX,
-    colorY,
-    transitionTime,
-    optionsMask: { executeIfOff },
-    optionsOverride: { executeIfOff },
-  };
-  return request;
-};
-
 MatterbridgeEndpoint.logLevel = LogLevel.DEBUG; // Set the log level for MatterbridgeEndpoint to DEBUG
 
 // Setup the test environment
@@ -228,7 +173,9 @@ describe('Matterbridge ' + NAME, () => {
 
   beforeAll(async () => {
     // Create the test environment
-    createTestEnvironment(NAME);
+    await createTestEnvironment();
+    // Create the server node and aggregator
+    await createServerNode(MATTER_PORT);
   });
 
   beforeEach(async () => {
@@ -237,7 +184,7 @@ describe('Matterbridge ' + NAME, () => {
   });
 
   afterEach(async () => {
-    await flushAsync(1, 1, 10);
+    await setDebug(false);
   });
 
   afterAll(async () => {
@@ -284,7 +231,8 @@ describe('Matterbridge ' + NAME, () => {
   }
 
   test('create and start the server node', async () => {
-    await startServerNode(NAME, MATTER_PORT);
+    // Start the server node if not in create-only mode
+    if (!MATTER_CREATE_ONLY) await startServerNode();
     expect(server).toBeDefined();
     expect(aggregator).toBeDefined();
   });
@@ -4103,7 +4051,9 @@ describe('Matterbridge ' + NAME, () => {
 
   test('close the server node', async () => {
     expect(server).toBeDefined();
-    await stopServerNode(server);
+    // Stop or flush the server node depending on the create-only mode
+    if (MATTER_CREATE_ONLY) await flushServerNode();
+    else await stopServerNode();
   });
 });
 

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -2,8 +2,8 @@
 
 /* eslint-disable no-console */
 
-const MATTER_PORT = 6000;
 const NAME = 'Platform';
+const MATTER_PORT = 6000;
 const HOMEDIR = path.join('jest', NAME);
 
 import * as fs from 'node:fs';
@@ -143,7 +143,7 @@ describe('HassPlatform', () => {
 
   beforeAll(async () => {
     // Create the test environment
-    await createMatterbridgeEnvironment(NAME);
+    await createMatterbridgeEnvironment();
   });
 
   beforeEach(() => {
@@ -170,8 +170,7 @@ describe('HassPlatform', () => {
   });
 
   afterEach(async () => {
-    // DrainEventLoop
-    await flushAsync(1, 1, 10);
+    await setDebug(false);
   });
 
   afterAll(async () => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -131,7 +131,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
   /** Supported helper domains */
   readonly supportedHelpersDomains = ['automation', 'scene', 'script', 'input_boolean', 'input_button'];
   /** Supported core domains */
-  readonly supportedCoreDomains = ['switch', 'light', 'lock', 'fan', 'cover', 'climate', 'valve', 'vacuum', 'remote', 'input_select', 'select']; // 'input_select' is an helper but we support it like core
+  readonly supportedCoreDomains = ['switch', 'light', 'lock', 'fan', 'cover', 'climate', 'valve', 'vacuum', 'remote', 'input_select', 'select', 'media_player']; // 'input_select' is an helper but we support it like core
   /** Supported other domains */
   readonly supportedOtherDomains = ['sensor', 'binary_sensor', 'event', 'button'];
   /** All supported domains */

--- a/src/module.ts
+++ b/src/module.ts
@@ -29,7 +29,7 @@ import path from 'node:path';
 import { bridgedNode, electricalSensor, MatterbridgeDynamicPlatform, MatterbridgeEndpoint, PlatformConfig, PlatformMatterbridge, powerSource, PrimitiveTypes } from 'matterbridge';
 import { AnsiLogger, CYAN, db, debugStringify, dn, er, hk, idn, ign, LogLevel, nf, or, rs, wr, YELLOW } from 'matterbridge/logger';
 import { ActionContext } from 'matterbridge/matter';
-import { BridgedDeviceBasicInformation, ColorControl, LevelControl, OnOff, PowerSource } from 'matterbridge/matter/clusters';
+import { BridgedDeviceBasicInformation, ColorControl, LevelControl, ModeSelect, OnOff, PowerSource } from 'matterbridge/matter/clusters';
 import { ClusterId, getClusterNameById } from 'matterbridge/matter/types';
 import { deepEqual, inspectError, isValidArray, isValidBoolean, isValidNumber, isValidObject, isValidString, waiter } from 'matterbridge/utils';
 
@@ -131,7 +131,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
   /** Supported helper domains */
   readonly supportedHelpersDomains = ['automation', 'scene', 'script', 'input_boolean', 'input_button'];
   /** Supported core domains */
-  readonly supportedCoreDomains = ['switch', 'light', 'lock', 'fan', 'cover', 'climate', 'valve', 'vacuum'];
+  readonly supportedCoreDomains = ['switch', 'light', 'lock', 'fan', 'cover', 'climate', 'valve', 'vacuum', 'remote', 'input_select', 'select']; // 'input_select' is an helper but we support it like core
   /** Supported other domains */
   readonly supportedOtherDomains = ['sensor', 'binary_sensor', 'event', 'button'];
   /** All supported domains */
@@ -181,6 +181,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       setImmediate(async () => {
         await this.onShutdown('Invalid configuration');
       });
+      this.wssSendSnackbarMessage('Home Assistant Plugin: configure Host and Token', 0, 'error');
       throw new Error('Host and token must be defined in the configuration');
     }
 
@@ -1288,6 +1289,10 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       } else {
         endpoint.log.debug(`Update event ${CYAN}${domain}${db}:${CYAN}${new_state.attributes['event_type']}${db} not supported for entity ${entityId}`);
       }
+    } else if (domain === 'select' || domain === 'input_select') {
+      const currentMode = new_state.attributes['options']?.indexOf(new_state.state);
+      if (currentMode >= 0) await endpoint.setAttribute(ModeSelect.Cluster.id, 'currentMode', currentMode + 1, endpoint.log);
+      else endpoint.log.debug(`Update ${CYAN}${new_state.attributes['options']?.join(', ')}${db} >>> ${CYAN}${new_state.state}${db} not supported for entity ${entityId}`);
     } else {
       // Update state of the device
       const hassUpdateState = hassUpdateStateConverter.filter((updateState) => updateState.domain === domain && updateState.state === new_state.state);

--- a/src/module.ts
+++ b/src/module.ts
@@ -81,6 +81,7 @@ export interface HomeAssistantPlatformConfig extends PlatformConfig {
   airQualityRegex: string;
   enableServerRvc: boolean;
   discardHiddenEntities: boolean;
+  virtualControlLabel: string;
 }
 
 /**
@@ -212,6 +213,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       this.config.airQualityRegex = isValidString(this.config.airQualityRegex, 1) ? this.config.airQualityRegex : '';
       this.config.enableServerRvc = isValidBoolean(this.config.enableServerRvc) ? this.config.enableServerRvc : true;
       this.config.discardHiddenEntities = isValidBoolean(this.config.discardHiddenEntities) ? this.config.discardHiddenEntities : false;
+      this.config.virtualControlLabel = isValidString(this.config.virtualControlLabel, 1) ? this.config.virtualControlLabel : '';
     }
 
     // Initialize air quality regex from config or use default

--- a/src/mutableDevice.test.ts
+++ b/src/mutableDevice.test.ts
@@ -1,9 +1,9 @@
 // src\mutableDevice.test.ts
 
-const MATTER_PORT = 6200;
 const NAME = 'MutableDevice';
-const HOMEDIR = path.join('jest', NAME);
+const MATTER_PORT = 6200;
 const MATTER_CREATE_ONLY = true;
+const HOMEDIR = path.join('jest', NAME);
 
 import path from 'node:path';
 
@@ -33,7 +33,19 @@ import {
   temperatureSensor,
   thermostatDevice,
 } from 'matterbridge';
-import { addDevice, aggregator, createTestEnvironment, destroyTestEnvironment, logKeepAlives, server, setupTest, startServerNode, stopServerNode } from 'matterbridge/jestutils';
+import {
+  addDevice,
+  aggregator,
+  createServerNode,
+  createTestEnvironment,
+  destroyTestEnvironment,
+  flushServerNode,
+  setDebug,
+  setupTest,
+  startServerNode,
+  stopServerNode,
+  subscribeAttributeMatterbridgeEndpointSpy,
+} from 'matterbridge/jestutils';
 import { AnsiLogger, LogLevel, TimestampFormat } from 'matterbridge/logger';
 import { UINT16_MAX, UINT32_MAX } from 'matterbridge/matter';
 import { BridgedDeviceBasicInformationServer, LevelControlServer, OnOffServer } from 'matterbridge/matter/behaviors';
@@ -81,15 +93,16 @@ describe('MutableDevice', () => {
     addBridgedEndpoint: jest.fn(async (pluginName: string, device: MatterbridgeEndpoint) => {}),
     removeBridgedEndpoint: jest.fn(async (pluginName: string, device: MatterbridgeEndpoint) => {}),
     removeAllBridgedEndpoints: jest.fn(async (pluginName: string) => {}),
+    addVirtualEndpoint: jest.fn(async (pluginName: string, name: string, type: 'light' | 'outlet' | 'switch' | 'mounted_switch', callback: () => Promise<void>) => {}),
   } as any;
-
-  const subscribeAttributeSpy = jest.spyOn(MatterbridgeEndpoint.prototype, 'subscribeAttribute');
 
   beforeAll(async () => {
     // Setup the Matter test environment
-    createTestEnvironment(NAME, MATTER_CREATE_ONLY);
-    // Start the server node and aggregator
-    await startServerNode(NAME, MATTER_PORT, undefined, MATTER_CREATE_ONLY);
+    await createTestEnvironment();
+    // Create the server node and aggregator
+    await createServerNode(MATTER_PORT);
+    // Start the server node if not in create-only mode
+    if (!MATTER_CREATE_ONLY) await startServerNode();
   });
 
   beforeEach(() => {
@@ -97,14 +110,15 @@ describe('MutableDevice', () => {
   });
 
   afterEach(async () => {
-    jest.clearAllMocks();
+    await setDebug(false);
   });
 
   afterAll(async () => {
-    // Stop the server node
-    await stopServerNode(server, MATTER_CREATE_ONLY);
+    // Stop or flush the server node depending on the create-only mode
+    if (MATTER_CREATE_ONLY) await flushServerNode();
+    else await stopServerNode();
     // Destroy the Matter test environment
-    await destroyTestEnvironment(MATTER_CREATE_ONLY);
+    await destroyTestEnvironment();
 
     // Restore all mocks
     jest.restoreAllMocks();
@@ -670,7 +684,7 @@ describe('MutableDevice', () => {
     device = mutableDevice.create();
     expect(device).toBeDefined();
     mutableDevice.logMutableDevice();
-    expect(subscribeAttributeSpy).toHaveBeenCalledTimes(2);
+    expect(subscribeAttributeMatterbridgeEndpointSpy).toHaveBeenCalledTimes(2);
 
     // Verify main endpoint
     expect(Array.from(device.deviceTypes.values()).map((d) => d.name)).toEqual(['MA-bridgedNode', 'MA-powerSource', 'MA-fan']);
@@ -711,7 +725,7 @@ describe('MutableDevice', () => {
     device = mutableDevice.create();
     expect(device).toBeDefined();
     mutableDevice.logMutableDevice();
-    expect(subscribeAttributeSpy).toHaveBeenCalledTimes(4);
+    expect(subscribeAttributeMatterbridgeEndpointSpy).toHaveBeenCalledTimes(4);
 
     // Verify main endpoint
     expect(Array.from(device.deviceTypes.values()).map((d) => d.name)).toEqual(['MA-bridgedNode', 'MA-powerSource']);
@@ -760,7 +774,7 @@ describe('MutableDevice', () => {
     device = mutableDevice.create(true);
     expect(device).toBeDefined();
     mutableDevice.logMutableDevice();
-    expect(subscribeAttributeSpy).toHaveBeenCalledTimes(4);
+    expect(subscribeAttributeMatterbridgeEndpointSpy).toHaveBeenCalledTimes(4);
 
     // Verify the remap
     expect(mutableDevice.size()).toBe(1);

--- a/src/mutableDevice.ts
+++ b/src/mutableDevice.ts
@@ -38,6 +38,7 @@ import {
   MatterbridgeEndpoint,
   MatterbridgeEndpointCommands,
   MatterbridgeFanControlServer,
+  MatterbridgeModeSelectServer,
   MatterbridgeSmokeCoAlarmServer,
   MatterbridgeThermostatServer,
   onOffLight,
@@ -56,6 +57,7 @@ import {
   FanControl,
   Groups,
   Identify,
+  ModeSelect,
   PowerSource,
   RvcCleanMode,
   RvcOperationalState,
@@ -776,6 +778,18 @@ export class MutableDevice {
         ],
         operationalState: RvcOperationalState.OperationalState.Docked,
         operationalError: { errorStateId: RvcOperationalState.ErrorState.NoError, errorStateDetails: 'Fully operational' },
+      }),
+    );
+    return this;
+  }
+
+  addSelect(endpoint: string, name: string, items: string[]): this {
+    const device = this.initializeEndpoint(endpoint);
+    device.clusterServersObjs.push(
+      getClusterServerObj(ModeSelect.Cluster.id, MatterbridgeModeSelectServer, {
+        description: name,
+        supportedModes: items.map((item, index) => ({ label: item, mode: index + 1, semanticTags: [] })),
+        currentMode: 1,
       }),
     );
     return this;

--- a/src/mutableDevice.ts
+++ b/src/mutableDevice.ts
@@ -39,6 +39,7 @@ import {
   MatterbridgeEndpointCommands,
   MatterbridgeFanControlServer,
   MatterbridgeModeSelectServer,
+  MatterbridgeOnOffServer,
   MatterbridgeSmokeCoAlarmServer,
   MatterbridgeThermostatServer,
   onOffLight,
@@ -46,7 +47,13 @@ import {
   onOffSwitch,
   PlatformMatterbridge,
 } from 'matterbridge';
-import { MatterbridgeRvcCleanModeServer, MatterbridgeRvcOperationalStateServer, MatterbridgeRvcRunModeServer } from 'matterbridge/devices';
+import {
+  MatterbridgeKeypadInputServer,
+  MatterbridgeMediaPlaybackServer,
+  MatterbridgeRvcCleanModeServer,
+  MatterbridgeRvcOperationalStateServer,
+  MatterbridgeRvcRunModeServer,
+} from 'matterbridge/devices';
 import { AnsiLogger, CYAN, db, debugStringify, idn, ign, LogLevel, rs, TimestampFormat } from 'matterbridge/logger';
 import { ActionContext, AtLeastOne, Behavior, UINT16_MAX, UINT32_MAX } from 'matterbridge/matter';
 import { BooleanStateServer, BridgedDeviceBasicInformationServer, PowerSourceServer } from 'matterbridge/matter/behaviors';
@@ -57,7 +64,10 @@ import {
   FanControl,
   Groups,
   Identify,
+  KeypadInput,
+  MediaPlayback,
   ModeSelect,
+  OnOff,
   PowerSource,
   RvcCleanMode,
   RvcOperationalState,
@@ -790,6 +800,42 @@ export class MutableDevice {
         description: name,
         supportedModes: items.map((item, index) => ({ label: item, mode: index + 1, semanticTags: [] })),
         currentMode: 1,
+      }),
+    );
+    return this;
+  }
+
+  addOnOff(endpoint: string, onOff: boolean): this {
+    const device = this.initializeEndpoint(endpoint);
+    device.clusterServersObjs.push(
+      getClusterServerObj(OnOff.Cluster.id, MatterbridgeOnOffServer.with(), {
+        onOff,
+      }),
+    );
+    return this;
+  }
+
+  addBasicVideoPlayer(endpoint: string): this {
+    const device = this.initializeEndpoint(endpoint);
+    device.clusterServersObjs.push(
+      getClusterServerObj(
+        MediaPlayback.Cluster.id,
+        MatterbridgeMediaPlaybackServer.enable({
+          commands: { next: true, previous: true, skipForward: true, skipBackward: true },
+        }),
+        {
+          currentState: MediaPlayback.PlaybackState.NotPlaying,
+        },
+      ),
+    );
+    return this;
+  }
+
+  addKeypadInput(endpoint: string): this {
+    const device = this.initializeEndpoint(endpoint);
+    device.clusterServersObjs.push(
+      getClusterServerObj(KeypadInput.Cluster.id, MatterbridgeKeypadInputServer, {
+        // No attributes for this cluster server, it only handles the KeypadInput command.
       }),
     );
     return this;


### PR DESCRIPTION
## [1.2.0] - 2026-04-24

### Breaking Changes

- [domains]: Domains `remote`, `select`, `input_select` and `media_player` are now supported. You may want to either use them with [filter](README.md#filter-by-label) and [select](README.md#device-entity-blacklist) or [exclude](README.md#domain-blacklist) all these domains if you don't need their entities or your controller doesn't support them. It is also possible to split them.
- [Split Entities]: The `Split Entities` config option is deprecated. Use `Split By Label`.

### Added

- [test]: Refactor tests to use the updated matterbridge test module.
- [remote]: Add `remote` domain.
- [select]: Add `select` domain.
- [input_select]: Add `input_select` domain.
- [media_player]: Add `media_player` domain.
- [Virtual Control]: Add the [Virtual Control Label](README.md#virtual-control-label) for accessibility controls (voice-friendly switches) on supported entities such as `select`, `input_select` and `media_player`.

### Changed

- [package]: Preliminary compatibility update to `matterbridge 3.8.0`, matter 1.5.1 and matter.js 0.17.0.
- [package]: Update dependencies.
- [package]: Bump `typescript` to v.6.0.3.
- [package]: Bump `eslint` to v.10.2.1.
- [package]: Bump `typescript-eslint` to v.8.59.0.
- [package]: Add `.vscode\settings.json`.
- [devcontainer]: Add `Claude Code for VS Code extension` to Dev Container.

<a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
