### PR TITLE
feat: Add option to invert cover commands

### DIFF
--- a/matterbridge-hass.schema.json
+++ b/matterbridge-hass.schema.json
@@ -229,6 +229,12 @@
       "type": "string",
       "default": ""
     },
+    "invertCoverOpenClose": {
+      "title": "Invert Cover Open/Close",
+      "description": "Invert the open and close services used for covers that operate inverted. When disabled, a position of 0% calls open_cover and 100% calls close_cover. When enabled, a position of 0% calls close_cover and 100% calls open_cover.",
+      "type": "boolean",
+      "default": false
+    },
     "debug": {
       "title": "Enable Debug",
       "description": "Enable the debug for the plugin (development only)",

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -483,6 +483,30 @@ describe('HassPlatform', () => {
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.WARN, expect.stringContaining(`Command ${ign}unknown${rs}${wr} not supported`));
   });
 
+  it('should invert cover open/close when invertCoverOpenClose is enabled', async () => {
+    expect(haPlatform).toBeDefined();
+    const device = new MatterbridgeEndpoint(bridgedNode, { id: 'invertedCover' }, true);
+    expect(device).toBeDefined();
+    if (!device) return;
+
+    const child = device.addChildDeviceTypeWithClusterServer('cover.cover_inverted', [coverDevice], [], { number: EndpointNumber(4) });
+    expect(child).toBeDefined();
+    child.number = EndpointNumber(4);
+
+    haPlatform.config.invertCoverOpenClose = true;
+    try {
+      jest.clearAllMocks();
+      await haPlatform.commandHandler({ endpoint: child, request: { liftPercent100thsValue: 0 }, cluster: 'windowCovering', attributes: {} }, 'cover.cover_inverted', 'goToLiftPercentage');
+      expect(callServiceSpy).toHaveBeenCalledWith('cover', 'close_cover', 'cover.cover_inverted');
+
+      jest.clearAllMocks();
+      await haPlatform.commandHandler({ endpoint: child, request: { liftPercent100thsValue: 10000 }, cluster: 'windowCovering', attributes: {} }, 'cover.cover_inverted', 'goToLiftPercentage');
+      expect(callServiceSpy).toHaveBeenCalledWith('cover', 'open_cover', 'cover.cover_inverted');
+    } finally {
+      haPlatform.config.invertCoverOpenClose = false;
+    }
+  });
+
   it('should call subscribeHandler', async () => {
     expect(haPlatform).toBeDefined();
     const device = new MatterbridgeEndpoint(bridgedNode, { id: 'test' }, true);

--- a/src/module.ts
+++ b/src/module.ts
@@ -95,6 +95,8 @@ export interface HomeAssistantPlatformConfig extends PlatformConfig {
   enableServerRvc: boolean;
   discardHiddenEntities: boolean;
   virtualControlLabel: string;
+  /** Invert the open/close services used for covers when handling goToLiftPercentage at 0%/100% */
+  invertCoverOpenClose: boolean;
 }
 
 /**
@@ -230,6 +232,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       this.config.enableServerRvc = isValidBoolean(this.config.enableServerRvc) ? this.config.enableServerRvc : true;
       this.config.discardHiddenEntities = isValidBoolean(this.config.discardHiddenEntities) ? this.config.discardHiddenEntities : false;
       this.config.virtualControlLabel = isValidString(this.config.virtualControlLabel, 1) ? this.config.virtualControlLabel : '';
+      this.config.invertCoverOpenClose = isValidBoolean(this.config.invertCoverOpenClose) ? this.config.invertCoverOpenClose : false;
     }
 
     // Initialize air quality regex from config or use default
@@ -1043,12 +1046,13 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       if (domain === 'cover') {
         // Special handling for cover goToLiftPercentage command. When goToLiftPercentage is called with 0, we may call the open service and when called with 10000 we may call the close service.
         // This allows to support also covers not supporting the set_cover_position service.
+        // When invertCoverOpenClose is enabled, the open and close services are swapped (0 calls close and 10000 calls open) for matter controller not following the specifications.
         // istanbul ignore else cause we modify only the goToLiftPercentage command for covers
         if (command === 'goToLiftPercentage' && data.request.liftPercent100thsValue === 10000) {
-          await this.ha.callService(hassCommand.domain, 'close_cover', entityId);
+          await this.ha.callService(hassCommand.domain, this.config.invertCoverOpenClose ? 'open_cover' : 'close_cover', entityId);
           return;
         } else if (command === 'goToLiftPercentage' && data.request.liftPercent100thsValue === 0) {
-          await this.ha.callService(hassCommand.domain, 'open_cover', entityId);
+          await this.ha.callService(hassCommand.domain, this.config.invertCoverOpenClose ? 'close_cover' : 'open_cover', entityId);
           return;
         }
       }


### PR DESCRIPTION
add a new configuration bool to adapt to non-specification compliant matter controller. Seems that Alexa is no behaving the same over different languages.