### PR TITLE
Add vacuum service area support and related features

### DIFF
--- a/src/control.entity.test.ts
+++ b/src/control.entity.test.ts
@@ -17,7 +17,16 @@ import { LevelControl } from 'matterbridge/matter/clusters';
 import { addControlEntity } from './control.entity.js';
 import { hassCommandConverter, hassDomainConverter, hassSubscribeConverter } from './converters.js';
 import { generateEntity, generateState } from './helpers.js';
-import { type HassConfig, type HassEntity, type HassState, HomeAssistant, MediaPlayerEntityFeature, MediaPlayerService, UnitOfTemperature } from './homeAssistant.js';
+import {
+  type HassConfig,
+  type HassEntity,
+  type HassState,
+  HomeAssistant,
+  MediaPlayerEntityFeature,
+  MediaPlayerService,
+  UnitOfTemperature,
+  VacuumEntityFeature,
+} from './homeAssistant.js';
 import { MutableDevice } from './mutableDevice.js';
 
 function createMockMutableDevice(): MutableDevice {
@@ -47,6 +56,7 @@ function createMockMutableDevice(): MutableDevice {
     addClusterServerHeatingCoolingThermostat: jest.fn(),
     addClusterServerCompleteFanControl: jest.fn(),
     addVacuum: jest.fn(),
+    addClusterServerServiceArea: jest.fn(),
     addSelect: jest.fn(),
     addOnOff: jest.fn(),
     addBasicVideoPlayer: jest.fn(),
@@ -57,13 +67,16 @@ function createMockMutableDevice(): MutableDevice {
 }
 
 const mockLog = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any;
-const mockPlatform = { config: { virtualControlLabel: '' }, log: mockLog } as any;
+const mockPlatform = { config: { virtualControlLabel: '' }, log: mockLog, ha: { hassAreas: new Map() } } as any;
 const commandHandler = jest.fn(async () => {}); // async signature required
 const subscribeHandler = jest.fn();
 type VirtualDeviceCallback = () => Promise<void>;
 
 describe('addControlEntity', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPlatform.ha.hassAreas.clear();
+  });
 
   const make = (domain: string, name: string, attrs: Record<string, any>) => {
     const md = createMockMutableDevice();
@@ -224,6 +237,30 @@ describe('addControlEntity', () => {
     // @ts-expect-error chainable return
     const vacuumCalls = md.addDeviceTypes.mock.calls.filter((c: any[]) => c[1] === roboticVacuumCleaner);
     expect(vacuumCalls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('vacuum does not add ServiceArea without CLEAN_AREA feature even with areas available', () => {
+    mockPlatform.ha.hassAreas.set('kitchen', { area_id: 'kitchen', name: 'Kitchen' });
+    const [md, e, s] = make('vacuum', 'robby', { activity: 'idle', supported_features: VacuumEntityFeature.START });
+    addControlEntity(mockPlatform, md, e as any, s as any, commandHandler, subscribeHandler as any);
+    expect(md.addClusterServerServiceArea).not.toHaveBeenCalled();
+  });
+
+  it('vacuum does not add ServiceArea when CLEAN_AREA is supported but no areas are available', () => {
+    const [md, e, s] = make('vacuum', 'robby', { activity: 'idle', supported_features: VacuumEntityFeature.CLEAN_AREA });
+    addControlEntity(mockPlatform, md, e as any, s as any, commandHandler, subscribeHandler as any);
+    expect(md.addClusterServerServiceArea).not.toHaveBeenCalled();
+  });
+
+  it('vacuum adds ServiceArea with the Home Assistant areas when CLEAN_AREA is supported', () => {
+    mockPlatform.ha.hassAreas.set('kitchen', { area_id: 'kitchen', name: 'Kitchen' });
+    mockPlatform.ha.hassAreas.set('bedroom', { area_id: 'bedroom', name: 'Bedroom' });
+    const [md, e, s] = make('vacuum', 'robby', { activity: 'idle', supported_features: VacuumEntityFeature.CLEAN_AREA });
+    addControlEntity(mockPlatform, md, e as any, s as any, commandHandler, subscribeHandler as any);
+    expect(md.addClusterServerServiceArea).toHaveBeenCalledWith(e.entity_id, [
+      { areaId: 1, mapId: null, areaInfo: { locationInfo: { locationName: 'Bedroom', floorNumber: null, areaType: null }, landmarkInfo: null } },
+      { areaId: 2, mapId: null, areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: null, areaType: null }, landmarkInfo: null } },
+    ]);
   });
 
   it('valve mapping', () => {

--- a/src/control.entity.test.ts
+++ b/src/control.entity.test.ts
@@ -16,7 +16,7 @@ import { LevelControl } from 'matterbridge/matter/clusters';
 
 import { addControlEntity } from './control.entity.js';
 import { hassCommandConverter, hassDomainConverter, hassSubscribeConverter } from './converters.js';
-import { generateEntity, generateState } from './helpers.js';
+import { generateEntity, generateState, hassAreaIdToMatterAreaId } from './helpers.js';
 import {
   type HassConfig,
   type HassEntity,
@@ -258,8 +258,8 @@ describe('addControlEntity', () => {
     const [md, e, s] = make('vacuum', 'robby', { activity: 'idle', supported_features: VacuumEntityFeature.CLEAN_AREA });
     addControlEntity(mockPlatform, md, e as any, s as any, commandHandler, subscribeHandler as any);
     expect(md.addClusterServerServiceArea).toHaveBeenCalledWith(e.entity_id, [
-      { areaId: 1, mapId: null, areaInfo: { locationInfo: { locationName: 'Bedroom', floorNumber: null, areaType: null }, landmarkInfo: null } },
-      { areaId: 2, mapId: null, areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: null, areaType: null }, landmarkInfo: null } },
+      { areaId: hassAreaIdToMatterAreaId('bedroom'), mapId: null, areaInfo: { locationInfo: { locationName: 'Bedroom', floorNumber: null, areaType: null }, landmarkInfo: null } },
+      { areaId: hassAreaIdToMatterAreaId('kitchen'), mapId: null, areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: null, areaType: null }, landmarkInfo: null } },
     ]);
   });
 

--- a/src/control.entity.ts
+++ b/src/control.entity.ts
@@ -31,7 +31,7 @@ import { ClusterId, getClusterNameById } from 'matterbridge/matter/types';
 import { isValidArray, isValidBoolean, isValidNumber, isValidString } from 'matterbridge/utils';
 
 import { getFeatureNames, hassCommandConverter, hassDomainConverter, hassSubscribeConverter, kelvinToMireds, roundTo, temp } from './converters.js';
-import { entityHasLabel, getDomain, getEntityName, getSortedHassAreas } from './helpers.js';
+import { entityHasLabel, getDomain, getEntityName, getSortedHassAreas, hassAreaIdToMatterAreaId } from './helpers.js';
 import {
   ClimateEntityFeature,
   ColorMode,
@@ -216,8 +216,8 @@ export function addControlEntity(
     );
     mutableDevice.addVacuum(endpointName);
     if (isValidNumber(state.attributes.supported_features) && (state.attributes.supported_features & VacuumEntityFeature.CLEAN_AREA) !== 0 && platform.ha.hassAreas.size > 0) {
-      const supportedAreas: ServiceArea.Area[] = getSortedHassAreas(platform.ha).map((area, index) => ({
-        areaId: index + 1,
+      const supportedAreas: ServiceArea.Area[] = getSortedHassAreas(platform.ha).map((area) => ({
+        areaId: hassAreaIdToMatterAreaId(area.area_id),
         mapId: null,
         areaInfo: { locationInfo: { locationName: area.name.slice(0, 32), floorNumber: null, areaType: null }, landmarkInfo: null },
       }));

--- a/src/control.entity.ts
+++ b/src/control.entity.ts
@@ -26,12 +26,12 @@
 import { colorTemperatureLight, dimmableLight, extendedColorLight, MatterbridgeEndpoint, PrimitiveTypes } from 'matterbridge';
 import { CYAN, db, debugStringify } from 'matterbridge/logger';
 import type { ActionContext } from 'matterbridge/matter';
-import { LevelControl } from 'matterbridge/matter/clusters';
+import { LevelControl, ServiceArea } from 'matterbridge/matter/clusters';
 import { ClusterId, getClusterNameById } from 'matterbridge/matter/types';
 import { isValidArray, isValidBoolean, isValidNumber, isValidString } from 'matterbridge/utils';
 
 import { getFeatureNames, hassCommandConverter, hassDomainConverter, hassSubscribeConverter, kelvinToMireds, roundTo, temp } from './converters.js';
-import { entityHasLabel, getDomain, getEntityName } from './helpers.js';
+import { entityHasLabel, getDomain, getEntityName, getSortedHassAreas } from './helpers.js';
 import {
   ClimateEntityFeature,
   ColorMode,
@@ -215,6 +215,14 @@ export function addControlEntity(
       `# vacuum device ${CYAN}${entity.entity_id}${db} supported_features: ${CYAN}${getFeatureNames(VacuumEntityFeature, state.attributes.supported_features)}${db}`,
     );
     mutableDevice.addVacuum(endpointName);
+    if (isValidNumber(state.attributes.supported_features) && (state.attributes.supported_features & VacuumEntityFeature.CLEAN_AREA) !== 0 && platform.ha.hassAreas.size > 0) {
+      const supportedAreas: ServiceArea.Area[] = getSortedHassAreas(platform.ha).map((area, index) => ({
+        areaId: index + 1,
+        mapId: null,
+        areaInfo: { locationInfo: { locationName: area.name.slice(0, 32), floorNumber: null, areaType: null }, landmarkInfo: null },
+      }));
+      mutableDevice.addClusterServerServiceArea(endpointName, supportedAreas);
+    }
   }
 
   // Configure the select.

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -563,6 +563,7 @@ export const hassCommandConverter: { command: CommandHandlers; domain: string; s
     { command: 'resume',                  domain: 'vacuum', service: 'start' },
     { command: 'goHome',                  domain: 'vacuum', service: 'return_to_base' },
     { command: 'changeToMode',            domain: 'vacuum', service: 'start' },
+    { command: 'selectAreas',             domain: 'vacuum', service: 'clean_area' },
 
     { command: 'on',                      domain: 'remote', service: 'turn_on' },
     { command: 'off',                     domain: 'remote', service: 'turn_off' },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -217,6 +217,16 @@ export function satisfiesAreaFilter(platform: HomeAssistantPlatform, deviceOrEnt
 }
 
 /**
+ * Returns the Home Assistant areas sorted by area_id for deterministic Matter AreaId assignment (index + 1).
+ *
+ * @param {HomeAssistant} ha - The Home Assistant instance.
+ * @returns {HassArea[]} - The Home Assistant areas sorted by area_id.
+ */
+export function getSortedHassAreas(ha: HomeAssistant): HassArea[] {
+  return Array.from(ha.hassAreas.values()).sort((a, b) => a.area_id.localeCompare(b.area_id));
+}
+
+/**
  * Checks if a given entity or device satisfies the configured label filter.
  *
  * @param {HomeAssistantPlatform} platform - The Home Assistant platform instance.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -217,13 +217,31 @@ export function satisfiesAreaFilter(platform: HomeAssistantPlatform, deviceOrEnt
 }
 
 /**
- * Returns the Home Assistant areas sorted by area_id for deterministic Matter AreaId assignment (index + 1).
+ * Returns the Home Assistant areas sorted by area_id for a deterministic Matter SupportedAreas ordering.
  *
  * @param {HomeAssistant} ha - The Home Assistant instance.
  * @returns {HassArea[]} - The Home Assistant areas sorted by area_id.
  */
 export function getSortedHassAreas(ha: HomeAssistant): HassArea[] {
-  return Array.from(ha.hassAreas.values()).sort((a, b) => a.area_id.localeCompare(b.area_id));
+  // Compare code points directly instead of localeCompare(), whose result depends on the runtime's default locale/ICU settings and would undermine the deterministic ordering across hosts.
+  return Array.from(ha.hassAreas.values()).sort((a, b) => (a.area_id < b.area_id ? -1 : a.area_id > b.area_id ? 1 : 0));
+}
+
+/**
+ * Derives a stable Matter ServiceArea AreaId from a Home Assistant area_id using the FNV-1a 32-bit hash.
+ *
+ * The AreaId must stay stable across restarts regardless of how the Home Assistant area registry grows, shrinks, or is reordered, so it cannot be a positional index into the current area list.
+ *
+ * @param {string} areaId - The Home Assistant area_id.
+ * @returns {number} - An unsigned 32-bit integer derived from the area_id, stable for as long as the area_id itself does not change.
+ */
+export function hassAreaIdToMatterAreaId(areaId: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < areaId.length; i++) {
+    hash ^= areaId.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
 }
 
 /**

--- a/src/homeAssistant.ts
+++ b/src/homeAssistant.ts
@@ -564,6 +564,7 @@ export enum VacuumEntityFeature {
   MAP = 2048,
   STATE = 4096, // Must be set by vacuum platforms derived from StateVacuumEntity
   START = 8192,
+  CLEAN_AREA = 16384,
 }
 /** Vacuum activity states. */
 export enum VacuumActivity {

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -44,6 +44,7 @@ import { BooleanState, BridgedDeviceBasicInformation, FanControl, IlluminanceMea
 import { EndpointNumber } from 'matterbridge/matter/types';
 import { wait } from 'matterbridge/utils';
 
+import { hassAreaIdToMatterAreaId } from './helpers.js';
 import { HassArea, HassConfig, HassDevice, HassEntity, HassLabel, HassServices, HassState, HomeAssistant } from './homeAssistant.js';
 import type { HomeAssistantPlatform as HomeAssistantPlatformType, HomeAssistantPlatformConfig } from './module.js';
 import { MutableDevice } from './mutableDevice.js';
@@ -486,12 +487,22 @@ describe('HassPlatform', () => {
     expect(callServiceSpy).not.toHaveBeenCalled();
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.WARN, expect.stringContaining(`Command ${ign}unknown${rs}${wr} not supported`));
 
-    // The Matter AreaId is the index (1-based) of the Home Assistant area sorted by area_id: area_a => 1, area_b => 2.
+    // The Matter AreaId is a stable hash of the Home Assistant area_id (see hassAreaIdToMatterAreaId).
     haPlatform.ha.hassAreas.set('area_b', { area_id: 'area_b', name: 'Bedroom' } as HassArea);
     haPlatform.ha.hassAreas.set('area_a', { area_id: 'area_a', name: 'Kitchen' } as HassArea);
     jest.clearAllMocks();
-    await haPlatform.commandHandler({ endpoint: child5, request: { newAreas: [2] }, cluster: 'serviceArea', attributes: {} }, 'vacuum.vacuum_5', 'selectAreas');
+    await haPlatform.commandHandler(
+      { endpoint: child5, request: { newAreas: [hassAreaIdToMatterAreaId('area_b')] }, cluster: 'serviceArea', attributes: {} },
+      'vacuum.vacuum_5',
+      'selectAreas',
+    );
     expect(callServiceSpy).toHaveBeenCalledWith('vacuum', 'clean_area', 'vacuum.vacuum_5', { cleaning_area_id: ['area_b'] });
+
+    // An AreaId that does not match any known Home Assistant area must not call the clean_area service.
+    jest.clearAllMocks();
+    await haPlatform.commandHandler({ endpoint: child5, request: { newAreas: [999999999] }, cluster: 'serviceArea', attributes: {} }, 'vacuum.vacuum_5', 'selectAreas');
+    expect(callServiceSpy).not.toHaveBeenCalled();
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.WARN, expect.stringContaining('did not resolve to any known Home Assistant area'));
     haPlatform.ha.hassAreas.clear();
   });
 

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -16,7 +16,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { jest } from '@jest/globals';
-import { bridgedNode, colorTemperatureLight, coverDevice, dimmableOutlet, MatterbridgeEndpoint, onOffOutlet } from 'matterbridge';
+import { bridgedNode, colorTemperatureLight, coverDevice, dimmableOutlet, MatterbridgeEndpoint, onOffOutlet, roboticVacuumCleaner } from 'matterbridge';
 import {
   addBridgedEndpointMatterbridgeSpy,
   addMatterbridgePlatform,
@@ -387,6 +387,10 @@ describe('HassPlatform', () => {
     expect(child4).toBeDefined();
     child4.number = EndpointNumber(4);
 
+    const child5 = device.addChildDeviceTypeWithClusterServer('vacuum.vacuum_5', [roboticVacuumCleaner], [], { number: EndpointNumber(5) });
+    expect(child5).toBeDefined();
+    child5.number = EndpointNumber(5);
+
     jest.clearAllMocks();
     await haPlatform.commandHandler({ endpoint: child1, request: {}, cluster: 'onOff', attributes: {} }, 'switch.switch_switch_1', 'on');
     expect(loggerLogSpy).toHaveBeenCalledWith(
@@ -481,6 +485,14 @@ describe('HassPlatform', () => {
     );
     expect(callServiceSpy).not.toHaveBeenCalled();
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.WARN, expect.stringContaining(`Command ${ign}unknown${rs}${wr} not supported`));
+
+    // The Matter AreaId is the index (1-based) of the Home Assistant area sorted by area_id: area_a => 1, area_b => 2.
+    haPlatform.ha.hassAreas.set('area_b', { area_id: 'area_b', name: 'Bedroom' } as HassArea);
+    haPlatform.ha.hassAreas.set('area_a', { area_id: 'area_a', name: 'Kitchen' } as HassArea);
+    jest.clearAllMocks();
+    await haPlatform.commandHandler({ endpoint: child5, request: { newAreas: [2] }, cluster: 'serviceArea', attributes: {} }, 'vacuum.vacuum_5', 'selectAreas');
+    expect(callServiceSpy).toHaveBeenCalledWith('vacuum', 'clean_area', 'vacuum.vacuum_5', { cleaning_area_id: ['area_b'] });
+    haPlatform.ha.hassAreas.clear();
   });
 
   it('should call subscribeHandler', async () => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -52,7 +52,7 @@ import { addHelperEntity } from './helper.entity.js';
 import {
   getDomain,
   getEntityName,
-  getSortedHassAreas,
+  hassAreaIdToMatterAreaId,
   isDeviceEntity,
   isDisabled,
   isHidden,
@@ -1171,9 +1171,17 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
         }
       }
       if (domain === 'vacuum' && command === 'selectAreas') {
-        // Special handling for the vacuum selectAreas command. The Matter AreaId is the index (1-based) of the Home Assistant area sorted by area_id, so we translate it back to the Home Assistant area_id before calling the clean_area service.
-        const areas = getSortedHassAreas(this.ha);
-        const cleaning_area_id = (data.request.newAreas as number[]).map((areaId) => areas[areaId - 1]?.area_id).filter((id): id is string => id !== undefined);
+        // Special handling for the vacuum selectAreas command. The Matter AreaId is a stable hash of the Home Assistant area_id (see hassAreaIdToMatterAreaId), so we translate it back to the Home Assistant area_id before calling the clean_area service.
+        const hassAreas = Array.from(this.ha.hassAreas.values());
+        const cleaning_area_id = (data.request.newAreas as number[])
+          .map((areaId) => hassAreas.find((area) => hassAreaIdToMatterAreaId(area.area_id) === areaId)?.area_id)
+          .filter((id): id is string => id !== undefined);
+        if (!isValidArray(cleaning_area_id, 1)) {
+          data.endpoint.log.warn(
+            `Command ${ign}${command}${rs}${wr} for domain ${CYAN}${domain}${wr} entity ${CYAN}${entityId}${wr} did not resolve to any known Home Assistant area, ignoring`,
+          );
+          return;
+        }
         await this.ha.callService('vacuum', 'clean_area', entityId, { cleaning_area_id });
         return;
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -49,7 +49,18 @@ import {
 } from './converters.js';
 import { addEventEntity } from './event.entity.js';
 import { addHelperEntity } from './helper.entity.js';
-import { getDomain, getEntityName, isDeviceEntity, isDisabled, isHidden, isIndividualEntity, isSplitEntity, satisfiesAreaFilter, satisfiesLabelFilter } from './helpers.js';
+import {
+  getDomain,
+  getEntityName,
+  getSortedHassAreas,
+  isDeviceEntity,
+  isDisabled,
+  isHidden,
+  isIndividualEntity,
+  isSplitEntity,
+  satisfiesAreaFilter,
+  satisfiesLabelFilter,
+} from './helpers.js';
 import {
   DeviceId,
   type EntityId,
@@ -1158,6 +1169,13 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
           this.offUpdatedEntities.delete(entityId);
           return;
         }
+      }
+      if (domain === 'vacuum' && command === 'selectAreas') {
+        // Special handling for the vacuum selectAreas command. The Matter AreaId is the index (1-based) of the Home Assistant area sorted by area_id, so we translate it back to the Home Assistant area_id before calling the clean_area service.
+        const areas = getSortedHassAreas(this.ha);
+        const cleaning_area_id = (data.request.newAreas as number[]).map((areaId) => areas[areaId - 1]?.area_id).filter((id): id is string => id !== undefined);
+        await this.ha.callService('vacuum', 'clean_area', entityId, { cleaning_area_id });
+        return;
       }
       // Normal execution for all the other commands and domains, we use the converter if present to get the service attributes and then call the service.
       const serviceAttributes: Record<string, HomeAssistantPrimitive> = hassCommand.converter ? hassCommand.converter(data.request, data.attributes, state) : undefined;

--- a/src/mutableDevice.test.ts
+++ b/src/mutableDevice.test.ts
@@ -567,6 +567,20 @@ describe('MutableDevice', () => {
     mutableDevice.destroy();
   });
 
+  it('should addClusterServerServiceArea', () => {
+    const mutableDevice = new MutableDevice(mockMatterbridge, 'Test Device vacuum service area');
+    mutableDevice.addDeviceTypes('', bridgedNode, roboticVacuumCleaner);
+    mutableDevice.addClusterServerServiceArea('', [
+      { areaId: 1, mapId: null, areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: null, areaType: null }, landmarkInfo: null } },
+    ]);
+
+    expect(mutableDevice.get()).toBeDefined();
+    expect(mutableDevice.get().clusterServersIds).toHaveLength(0);
+    expect(mutableDevice.get().clusterServersObjs).toHaveLength(1);
+
+    mutableDevice.destroy();
+  });
+
   it('should create a MatterbridgeDevice', async () => {
     const mutableDevice = new MutableDevice(mockMatterbridge, 'Test Device composed');
     mutableDevice.addDeviceTypes('', bridgedNode, powerSource);

--- a/src/mutableDevice.ts
+++ b/src/mutableDevice.ts
@@ -40,6 +40,7 @@ import {
   MatterbridgeFanControlServer,
   MatterbridgeModeSelectServer,
   MatterbridgeOnOffServer,
+  MatterbridgeServiceAreaServer,
   MatterbridgeSmokeCoAlarmServer,
   MatterbridgeThermostatServer,
   onOffLight,
@@ -72,6 +73,7 @@ import {
   RvcCleanMode,
   RvcOperationalState,
   RvcRunMode,
+  ServiceArea,
   SmokeCoAlarm,
   Thermostat,
 } from 'matterbridge/matter/clusters';
@@ -782,6 +784,27 @@ export class MutableDevice {
         ],
         operationalState: RvcOperationalState.OperationalState.Docked,
         operationalError: { errorStateId: RvcOperationalState.ErrorState.NoError, errorStateDetails: 'Fully operational' },
+      }),
+    );
+    return this;
+  }
+
+  /**
+   * Adds a ServiceArea Cluster Server to the given endpoint.
+   *
+   * @param {string} endpoint - The endpoint to which the cluster server will be added.
+   * @param {ServiceArea.Area[]} supportedAreas - The supported areas for the ServiceArea cluster.
+   *
+   * @returns {this} The current MutableDevice instance for chaining.
+   */
+  addClusterServerServiceArea(endpoint: string, supportedAreas: ServiceArea.Area[]): this {
+    const device = this.initializeEndpoint(endpoint);
+    device.clusterServersObjs.push(
+      getClusterServerObj(ServiceArea.id, MatterbridgeServiceAreaServer, {
+        supportedAreas,
+        selectedAreas: [],
+        currentArea: null,
+        estimatedEndTime: null,
       }),
     );
     return this;

--- a/src/mutableDevice.ts
+++ b/src/mutableDevice.ts
@@ -800,11 +800,15 @@ export class MutableDevice {
   addClusterServerServiceArea(endpoint: string, supportedAreas: ServiceArea.Area[]): this {
     const device = this.initializeEndpoint(endpoint);
     device.clusterServersObjs.push(
-      getClusterServerObj(ServiceArea.id, MatterbridgeServiceAreaServer, {
+      // The Maps feature must be enabled so supportedMaps is a valid attribute: ServiceAreaBaseServer.initialize() unconditionally
+      // reads state.supportedMaps.length, which crashes when the attribute is absent from the state (matches the pattern used by
+      // MatterbridgeEndpoint.createDefaultServiceAreaClusterServer() in matterbridge core).
+      getClusterServerObj(ServiceArea.id, MatterbridgeServiceAreaServer.with(ServiceArea.Feature.Maps), {
         supportedAreas,
         selectedAreas: [],
         currentArea: null,
         estimatedEndTime: null,
+        supportedMaps: [],
       }),
     );
     return this;


### PR DESCRIPTION
## Feature: ServiceArea for vacuum entities

**Goal**: let a Matter controller pick a room to clean on a Home Assistant vacuum entity, using the Matter `ServiceArea` cluster (`SupportedAreas` + `SelectAreas`).

**HA research findings**:
- `async_get_segments`/`async_clean_segments` are **not** publicly callable — internal to HA, only invoked by the public `vacuum.clean_area` service.
- Only public path: `vacuum.clean_area` service with `cleaning_area_id` = list of **Home Assistant Area IDs** (not the vacuum's own room segments).
- Requires the `VacuumEntityFeature.CLEAN_AREA` (`16384`) bit in `supported_features`.

**Scope chosen**: expose the entire HA Area registry as `SupportedAreas`, only when the vacuum entity supports `CLEAN_AREA`.

**Changes made** (6 source files + matching tests):

| File | Change |
|---|---|
| `homeAssistant.ts` | Added `CLEAN_AREA = 16384` to `VacuumEntityFeature` |
| `helpers.ts` | Added `getSortedHassAreas()` — deterministic sort for stable Matter `AreaId` assignment |
| `mutableDevice.ts` | Added `addClusterServerServiceArea()` |
| `control.entity.ts` | Wires `ServiceArea` cluster creation into the vacuum block, gated on `CLEAN_AREA` |
| `converters.ts` | Added `selectAreas` → `clean_area` command entry |
| `module.ts` | `commandHandler` special case: translates Matter `newAreas` (numeric) back to HA Area IDs, calls `vacuum.clean_area` |
| `*.test.ts` | Unit tests added in `control.entity.test.ts`, `mutableDevice.test.ts`, `module.test.ts` |

**Correctness confirmed**: `SelectedAreas` attribute updates are handled automatically by matter.js's own `ServiceAreaServer.selectAreas()` base implementation (validates against `SupportedAreas`, sets `state.selectedAreas`) — no extra code needed on the plugin side.
