### PR TITLE
feat: expose labeled climate entities as Room Air Conditioner (Matter 1.2, 0x0072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ If you like this project and find it useful, please consider giving it a **star*
 
 > WARNING: The domains button, remote and media_player include an OnOff cluster. This will not make it possible to merge the entities on the same endpoint: if you have Alexa or Google you may want to either black list those domains or to split their entities.
 
+## [Unreleased]
+
+### Added
+
+- [climate]: Added the `airConditionerLabel` config option: climate entities with this label are exposed as a Room Air Conditioner device (Matter 1.2, 0x0072) instead of a Thermostat device. The device gets the required Dead Front OnOff cluster mapped to climate turn_on/turn_off and, when the entity has fan_modes, a base Fan Control cluster mapped to the climate fan modes (including Auto when available). The hvac modes of the entity still select the Thermostat cluster features, so cooling only units get a cooling only Thermostat cluster.
+- [climate]: Added the dry and fan_only states and the fan_mode attribute updates for climate entities exposed as air conditioner.
+- [module]: The state and attribute update converters now skip attributes the endpoint doesn't have, instead of logging an error.
+
 ## [1.3.1] - 2026-06-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Pair Matterbridge to your controller.
 | lock         | locked, locking, unlocking, unlocked       |                                                                                         |
 | fan          | on, off                                    | percentage, preset_mode (1), direction, oscillating                                     |
 | cover        | open, closed, opening, closing             | current_position                                                                        |
-| climate      | off, heat, cool, heat_cool, auto           | current_temperature, temperature, target_temp_low, target_temp_high, min_temp, max_temp |
+| climate (3)  | off, heat, cool, heat_cool, auto, dry, fan_only | current_temperature, temperature, target_temp_low, target_temp_high, min_temp, max_temp, fan_mode (3) |
 | valve        | open, closed, opening, closing             | current_position                                                                        |
 | vacuum (2)   | idle, cleaning, paused, docked, returning  |                                                                                         |
 | button       |                                            |                                                                                         |
@@ -87,6 +87,8 @@ Pair Matterbridge to your controller.
 (1) - Supported preset_modes: auto, low, medium, high.
 
 (2) - The Apple Home crashes if the Rvc is inside the bridge. If you pair with Apple Home use the server mode in the config (it will create an autonomous device with its QR code in the Devices panel of the Home page) and disable or split all other entities that are not the rvc.
+
+(3) - Climate entities are exposed as a Thermostat device by default. Climate entities with the label configured in `airConditionerLabel` are exposed as a Room Air Conditioner device (Matter 1.2): the device gets an OnOff cluster (Dead Front) mapped to climate turn_on/turn_off and, when the entity has fan_modes, a Fan Control cluster mapped to the climate fan modes (the dry and fan_only states and the fan_mode attribute are only mapped for air conditioners). In both cases the hvac modes of the entity select the Thermostat cluster features, so cooling only units get a cooling only Thermostat cluster and the controller doesn't show a Heat mode.
 
 These domains are supported also like individual and split entities.
 

--- a/matterbridge-hass.schema.json
+++ b/matterbridge-hass.schema.json
@@ -229,6 +229,12 @@
       "type": "string",
       "default": ""
     },
+    "airConditionerLabel": {
+      "title": "Air Conditioner Label",
+      "description": "Expose climate entities with this label (use label name) as a Room Air Conditioner device (Matter 1.2) instead of a Thermostat device. The device gets an OnOff cluster (Dead Front) mapped to climate turn_on/turn_off and, when the entity has fan_modes, a Fan Control cluster mapped to the climate fan modes. The hvac modes of the entity still select the Thermostat features (e.g. cooling only units get a cooling only Thermostat cluster).",
+      "type": "string",
+      "default": ""
+    },
     "debug": {
       "title": "Enable Debug",
       "description": "Enable the debug for the plugin (development only)",

--- a/src/control.entity.test.ts
+++ b/src/control.entity.test.ts
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import {
+  airConditioner,
   colorTemperatureLight,
   coverDevice,
   dimmableLight,
@@ -12,7 +13,7 @@ import {
   thermostatDevice,
   waterValve,
 } from 'matterbridge';
-import { LevelControl } from 'matterbridge/matter/clusters';
+import { FanControl, LevelControl } from 'matterbridge/matter/clusters';
 
 import { addControlEntity } from './control.entity.js';
 import { hassCommandConverter, hassDomainConverter, hassSubscribeConverter } from './converters.js';
@@ -39,6 +40,12 @@ function createMockMutableDevice(): MutableDevice {
     }),
     setFriendlyName: jest.fn(),
     get: jest.fn((ep: string) => ({ deviceTypes: ensure(ep).deviceTypes })),
+    removeDeviceTypes: jest.fn((ep: string, deviceType: any) => {
+      ensure(ep);
+      endpoints[ep].deviceTypes = endpoints[ep].deviceTypes.filter((dt) => dt.code !== deviceType.code);
+      // @ts-expect-error chainable return
+      return this;
+    }),
     addClusterServerColorTemperatureColorControl: jest.fn(),
     addClusterServerColorControl: jest.fn(),
     addClusterServerAutoModeThermostat: jest.fn(),
@@ -46,6 +53,8 @@ function createMockMutableDevice(): MutableDevice {
     addClusterServerCoolingThermostat: jest.fn(),
     addClusterServerHeatingCoolingThermostat: jest.fn(),
     addClusterServerCompleteFanControl: jest.fn(),
+    addClusterServerBaseFanControl: jest.fn(),
+    addClusterServerDeadFrontOnOff: jest.fn(),
     addVacuum: jest.fn(),
     addSelect: jest.fn(),
     addOnOff: jest.fn(),
@@ -461,6 +470,77 @@ describe('addControlEntity', () => {
       callback('new', 'old', {} as any, e.entity_id, call[1], call[2]);
     }
     expect(subscribeHandler).toHaveBeenCalledTimes(calls.length);
+  });
+
+  it('climate with the air conditioner label is exposed as a room air conditioner', () => {
+    const [md, e, s] = make('climate', 'office_ac', {
+      hvac_modes: ['off', 'cool', 'dry', 'fan_only'],
+      current_temperature: 24,
+      temperature: 22,
+      fan_modes: ['Silent', 'Low', 'Medium', 'High', 'Full', 'Auto'],
+      fan_mode: 'Auto',
+      friendly_name: 'Office AC',
+    });
+    (s as any).state = 'cool';
+    (e as any).labels = ['ac_label_id'];
+    const platform = {
+      config: { virtualControlLabel: '', airConditionerLabel: 'Air Conditioner' },
+      log: mockLog,
+      ha: { hassLabels: new Map([['ac_label_id', { label_id: 'ac_label_id', name: 'Air Conditioner' }]]) },
+    } as any;
+    addControlEntity(platform, md, e as any, s as any, commandHandler, subscribeHandler as any);
+    expect(md.removeDeviceTypes).toHaveBeenCalledWith(e.entity_id, thermostatDevice);
+    expect(md.addDeviceTypes).toHaveBeenCalledWith(e.entity_id, airConditioner);
+    expect(md.addClusterServerDeadFrontOnOff).toHaveBeenCalledWith(e.entity_id, true);
+    expect(md.addClusterServerBaseFanControl).toHaveBeenCalledWith(e.entity_id, FanControl.FanMode.Auto, FanControl.FanModeSequence.OffLowMedHighAuto, 0, 0);
+    expect(md.addClusterServerCoolingThermostat).toHaveBeenCalled();
+    expect(md.addClusterServerHeatingThermostat).not.toHaveBeenCalled();
+  });
+
+  it('climate with the air conditioner label and state off adds a dead front OnOff cluster off', () => {
+    const [md, e, s] = make('climate', 'office_ac', { hvac_modes: ['off', 'cool'], current_temperature: 24, temperature: 22, fan_modes: ['low', 'high'], fan_mode: 'low' });
+    (s as any).state = 'off';
+    (e as any).labels = ['ac_label_id'];
+    const platform = {
+      config: { virtualControlLabel: '', airConditionerLabel: 'Air Conditioner' },
+      log: mockLog,
+      ha: { hassLabels: new Map([['ac_label_id', { label_id: 'ac_label_id', name: 'Air Conditioner' }]]) },
+    } as any;
+    addControlEntity(platform, md, e as any, s as any, commandHandler, subscribeHandler as any);
+    expect(md.addClusterServerDeadFrontOnOff).toHaveBeenCalledWith(e.entity_id, false);
+    // No auto fan mode: the fan mode sequence has no Auto
+    expect(md.addClusterServerBaseFanControl).toHaveBeenCalledWith(e.entity_id, FanControl.FanMode.Low, FanControl.FanModeSequence.OffLowMedHigh, 50, 50);
+  });
+
+  it('climate with the air conditioner label and no fan_modes adds no fan control cluster', () => {
+    const [md, e, s] = make('climate', 'office_ac', { hvac_modes: ['off', 'cool'], current_temperature: 24, temperature: 22 });
+    (s as any).state = 'cool';
+    (e as any).labels = ['ac_label_id'];
+    const platform = {
+      config: { virtualControlLabel: '', airConditionerLabel: 'Air Conditioner' },
+      log: mockLog,
+      ha: { hassLabels: new Map([['ac_label_id', { label_id: 'ac_label_id', name: 'Air Conditioner' }]]) },
+    } as any;
+    addControlEntity(platform, md, e as any, s as any, commandHandler, subscribeHandler as any);
+    expect(md.addClusterServerDeadFrontOnOff).toHaveBeenCalledWith(e.entity_id, true);
+    expect(md.addClusterServerBaseFanControl).not.toHaveBeenCalled();
+  });
+
+  it('climate without the air conditioner label stays a thermostat', () => {
+    const [md, e, s] = make('climate', 'plain_thermostat', { hvac_modes: ['off', 'cool'], current_temperature: 24, temperature: 22, fan_modes: ['low', 'high'] });
+    (s as any).state = 'cool';
+    (e as any).labels = ['other_label_id'];
+    const platform = {
+      config: { virtualControlLabel: '', airConditionerLabel: 'Air Conditioner' },
+      log: mockLog,
+      ha: { hassLabels: new Map([['ac_label_id', { label_id: 'ac_label_id', name: 'Air Conditioner' }]]) },
+    } as any;
+    addControlEntity(platform, md, e as any, s as any, commandHandler, subscribeHandler as any);
+    expect(md.addDeviceTypes).toHaveBeenCalledWith(e.entity_id, thermostatDevice);
+    expect(md.removeDeviceTypes).not.toHaveBeenCalled();
+    expect(md.addClusterServerDeadFrontOnOff).not.toHaveBeenCalled();
+    expect(md.addClusterServerBaseFanControl).not.toHaveBeenCalled();
+    expect(md.addClusterServerCoolingThermostat).toHaveBeenCalled();
   });
 
   it('climate domain with unsupported hvac modes adds no thermostat cluster servers', () => {

--- a/src/control.entity.ts
+++ b/src/control.entity.ts
@@ -23,14 +23,24 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable jsdoc/reject-function-type */
 
-import { colorTemperatureLight, dimmableLight, extendedColorLight, MatterbridgeEndpoint, PrimitiveTypes } from 'matterbridge';
+import { airConditioner, colorTemperatureLight, dimmableLight, extendedColorLight, MatterbridgeEndpoint, PrimitiveTypes, thermostatDevice } from 'matterbridge';
 import { CYAN, db, debugStringify } from 'matterbridge/logger';
 import type { ActionContext } from 'matterbridge/matter';
-import { LevelControl } from 'matterbridge/matter/clusters';
+import { FanControl, LevelControl } from 'matterbridge/matter/clusters';
 import { ClusterId, getClusterNameById } from 'matterbridge/matter/types';
 import { isValidArray, isValidBoolean, isValidNumber, isValidString } from 'matterbridge/utils';
 
-import { getFeatureNames, hassCommandConverter, hassDomainConverter, hassSubscribeConverter, kelvinToMireds, roundTo, temp } from './converters.js';
+import {
+  getFeatureNames,
+  hassCommandConverter,
+  hassDomainConverter,
+  hassSubscribeConverter,
+  kelvinToMireds,
+  matterFanModeFromHassClimateFanMode,
+  matterFanPercentFromHassClimateFanMode,
+  roundTo,
+  temp,
+} from './converters.js';
 import { entityHasLabel, getDomain, getEntityName } from './helpers.js';
 import {
   ClimateEntityFeature,
@@ -158,6 +168,30 @@ export function addControlEntity(
       mutableDevice.addClusterServerColorTemperatureColorControl(endpointName, minMireds, maxMireds);
     } else {
       mutableDevice.addClusterServerColorControl(endpointName, minMireds, maxMireds);
+    }
+  }
+
+  // Configure the climate entities exposed as Room Air Conditioner (Matter 1.2, 0x0072) with the airConditionerLabel.
+  // The Thermostat device type is replaced by the Air Conditioner device type, the required Dead Front OnOff cluster is
+  // added and, when the entity has fan_modes, a base Fan Control cluster mapped to the climate fan modes is added.
+  // prettier-ignore
+  if (domain === 'climate' && entityHasLabel(platform, entity, platform.config.airConditionerLabel)) {
+    platform.log.debug(`= air conditioner device ${CYAN}${entity.entity_id}${db} state: ${CYAN}${state.state}${db} fan_modes: ${CYAN}${state.attributes['fan_modes']}${db} fan_mode: ${CYAN}${state.attributes['fan_mode']}${db}`);
+    mutableDevice.removeDeviceTypes(endpointName, thermostatDevice);
+    mutableDevice.addDeviceTypes(endpointName, airConditioner);
+    mutableDevice.addClusterServerDeadFrontOnOff(endpointName, state.state !== 'off' && state.state !== 'unavailable');
+    if (isValidArray(state.attributes['fan_modes'], 1)) {
+      const fanModes = state.attributes['fan_modes'] as string[];
+      const hasAuto = fanModes.some((mode) => isValidString(mode, 1) && ['auto', 'smart'].includes(mode.toLowerCase()));
+      const fanMode = isValidString(state.attributes['fan_mode'], 1) ? matterFanModeFromHassClimateFanMode(state.attributes['fan_mode'], fanModes) : null;
+      const percent = isValidString(state.attributes['fan_mode'], 1) ? matterFanPercentFromHassClimateFanMode(state.attributes['fan_mode'], fanModes) : null;
+      mutableDevice.addClusterServerBaseFanControl(
+        endpointName,
+        fanMode ?? FanControl.FanMode.Off,
+        hasAuto ? FanControl.FanModeSequence.OffLowMedHighAuto : FanControl.FanModeSequence.OffLowMedHigh,
+        percent ?? 0,
+        percent ?? 0,
+      );
     }
   }
 

--- a/src/converters.test.ts
+++ b/src/converters.test.ts
@@ -3,13 +3,15 @@
 /* eslint-disable jest/no-conditional-expect */
 
 import { airQualitySensor, electricalSensor, powerSource, pressureSensor } from 'matterbridge';
-import { AirQuality, FanControl, Thermostat } from 'matterbridge/matter/clusters';
+import { AirQuality, FanControl, OnOff, Thermostat } from 'matterbridge/matter/clusters';
 
 import {
   clamp,
   convertHAXYToMatter,
   convertMatterXYToHA,
   getFeatureNames,
+  hassClimateFanModeFromMatterFanMode,
+  hassClimateFanModeFromMatterFanPercent,
   hassCommandConverter,
   hassDomainBinarySensorsConverter,
   hassDomainConverter,
@@ -18,6 +20,8 @@ import {
   hassUpdateAttributeConverter,
   hassUpdateStateConverter,
   kelvinToMireds,
+  matterFanModeFromHassClimateFanMode,
+  matterFanPercentFromHassClimateFanMode,
   miredsToKelvin,
   roundTo,
   temp,
@@ -124,10 +128,80 @@ describe('HassPlatform converters', () => {
   it('should verify the hassUpdateStateConverter converter', () => {
     hassUpdateStateConverter.forEach((converter) => {
       expect(converter.domain.length).toBeGreaterThan(0);
-      if (converter.domain === 'climate' && converter.state === 'auto') {
+      if (converter.domain === 'climate' && converter.state === 'auto' && converter.clusterId !== OnOff.id) {
+        // The Thermostat systemMode is not updated for the auto state; the OnOff row (air conditioner Dead Front) is.
         expect(converter.clusterId).toBeUndefined();
       }
     });
+  });
+
+  it('should convert hass climate fan modes to matter fan modes', () => {
+    const mideaFanModes = ['Silent', 'Low', 'Medium', 'High', 'Full', 'Auto'];
+    // Canonical names don't need the fan_modes list
+    expect(matterFanModeFromHassClimateFanMode('auto', mideaFanModes)).toBe(FanControl.FanMode.Auto);
+    expect(matterFanModeFromHassClimateFanMode('smart')).toBe(FanControl.FanMode.Auto);
+    expect(matterFanModeFromHassClimateFanMode('off')).toBe(FanControl.FanMode.Off);
+    expect(matterFanModeFromHassClimateFanMode('Low', mideaFanModes)).toBe(FanControl.FanMode.Low);
+    expect(matterFanModeFromHassClimateFanMode('medium')).toBe(FanControl.FanMode.Medium);
+    expect(matterFanModeFromHassClimateFanMode('mid')).toBe(FanControl.FanMode.Medium);
+    expect(matterFanModeFromHassClimateFanMode('High', mideaFanModes)).toBe(FanControl.FanMode.High);
+    // Non canonical names are ranked by their position in the speed fan modes
+    expect(matterFanModeFromHassClimateFanMode('Silent', mideaFanModes)).toBe(FanControl.FanMode.Low);
+    expect(matterFanModeFromHassClimateFanMode('Full', mideaFanModes)).toBe(FanControl.FanMode.High);
+    expect(matterFanModeFromHassClimateFanMode('turbo', ['quiet', 'turbo'])).toBe(FanControl.FanMode.High);
+    expect(matterFanModeFromHassClimateFanMode('quiet', ['quiet', 'turbo'])).toBe(FanControl.FanMode.Low);
+    expect(matterFanModeFromHassClimateFanMode('single', ['single'])).toBe(FanControl.FanMode.High);
+    // Unknown names and invalid values return null
+    expect(matterFanModeFromHassClimateFanMode('unknown', mideaFanModes)).toBe(null);
+    expect(matterFanModeFromHassClimateFanMode('turbo')).toBe(null);
+    expect(matterFanModeFromHassClimateFanMode('')).toBe(null);
+  });
+
+  it('should convert matter fan modes to hass climate fan modes', () => {
+    const mideaFanModes = ['Silent', 'Low', 'Medium', 'High', 'Full', 'Auto'];
+    // Canonical names are preferred when present
+    expect(hassClimateFanModeFromMatterFanMode(FanControl.FanMode.Auto, mideaFanModes)).toBe('Auto');
+    expect(hassClimateFanModeFromMatterFanMode(FanControl.FanMode.Low, mideaFanModes)).toBe('Low');
+    expect(hassClimateFanModeFromMatterFanMode(FanControl.FanMode.Medium, mideaFanModes)).toBe('Medium');
+    expect(hassClimateFanModeFromMatterFanMode(FanControl.FanMode.High, mideaFanModes)).toBe('High');
+    // The speed fan modes are sampled positionally when no canonical name is present
+    expect(hassClimateFanModeFromMatterFanMode(FanControl.FanMode.Low, ['quiet', 'strong', 'turbo'])).toBe('quiet');
+    expect(hassClimateFanModeFromMatterFanMode(FanControl.FanMode.Medium, ['quiet', 'strong', 'turbo'])).toBe('strong');
+    expect(hassClimateFanModeFromMatterFanMode(FanControl.FanMode.High, ['quiet', 'strong', 'turbo'])).toBe('turbo');
+    // Auto falls back to the highest speed when no auto fan mode is present
+    expect(hassClimateFanModeFromMatterFanMode(FanControl.FanMode.Auto, ['quiet', 'turbo'])).toBe('turbo');
+    // Off returns null: the caller turns the entity off
+    expect(hassClimateFanModeFromMatterFanMode(FanControl.FanMode.Off, mideaFanModes)).toBe(null);
+    // Invalid values return null
+    expect(hassClimateFanModeFromMatterFanMode(FanControl.FanMode.Low)).toBe(null);
+    expect(hassClimateFanModeFromMatterFanMode(100 as FanControl.FanMode, mideaFanModes)).toBe(null);
+  });
+
+  it('should convert hass climate fan modes to matter fan percent', () => {
+    const mideaFanModes = ['Silent', 'Low', 'Medium', 'High', 'Full', 'Auto'];
+    expect(matterFanPercentFromHassClimateFanMode('Silent', mideaFanModes)).toBe(20);
+    expect(matterFanPercentFromHassClimateFanMode('Low', mideaFanModes)).toBe(40);
+    expect(matterFanPercentFromHassClimateFanMode('Medium', mideaFanModes)).toBe(60);
+    expect(matterFanPercentFromHassClimateFanMode('High', mideaFanModes)).toBe(80);
+    expect(matterFanPercentFromHassClimateFanMode('Full', mideaFanModes)).toBe(100);
+    // Auto and unknown names return null
+    expect(matterFanPercentFromHassClimateFanMode('Auto', mideaFanModes)).toBe(null);
+    expect(matterFanPercentFromHassClimateFanMode('unknown', mideaFanModes)).toBe(null);
+    expect(matterFanPercentFromHassClimateFanMode('', mideaFanModes)).toBe(null);
+  });
+
+  it('should convert matter fan percent to hass climate fan modes', () => {
+    const mideaFanModes = ['Silent', 'Low', 'Medium', 'High', 'Full', 'Auto'];
+    expect(hassClimateFanModeFromMatterFanPercent(1, mideaFanModes)).toBe('Silent');
+    expect(hassClimateFanModeFromMatterFanPercent(20, mideaFanModes)).toBe('Silent');
+    expect(hassClimateFanModeFromMatterFanPercent(50, mideaFanModes)).toBe('Medium');
+    expect(hassClimateFanModeFromMatterFanPercent(80, mideaFanModes)).toBe('High');
+    expect(hassClimateFanModeFromMatterFanPercent(100, mideaFanModes)).toBe('Full');
+    // Percent 0 returns null: the caller turns the entity off
+    expect(hassClimateFanModeFromMatterFanPercent(0, mideaFanModes)).toBe(null);
+    // Invalid values return null
+    expect(hassClimateFanModeFromMatterFanPercent(50, [])).toBe(null);
+    expect(hassClimateFanModeFromMatterFanPercent(101, mideaFanModes)).toBe(null);
   });
 
   it('should verify the hassUpdateAttributeConverter converter', () => {

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -322,6 +322,116 @@ function getSelectOptionFromMode(request: Record<string, unknown>, state: HassSt
   return { option: options[optionIndex] };
 }
 
+/**
+ * Returns the ordered list of speed fan modes of a climate entity (auto, smart and off excluded).
+ *
+ * @param {string[] | undefined} fanModes - The climate entity fan_modes attribute.
+ * @returns {string[]} The fan modes that represent a speed, in the order provided by Home Assistant (assumed ascending).
+ */
+function getClimateSpeedFanModes(fanModes?: string[]): string[] {
+  if (!isValidArray(fanModes, 1)) return [];
+  return fanModes.filter((mode) => isValidString(mode, 1) && !['auto', 'smart', 'off'].includes(mode.toLowerCase()));
+}
+
+/**
+ * Converts a Home Assistant climate fan mode string to a Matter FanControl.FanMode.
+ *
+ * Canonical names (auto, smart, off, low, medium, mid, high) are matched first; any other name is ranked
+ * by its position in the ordered list of speed fan modes and mapped to Low / Medium / High.
+ *
+ * @param {string} fanMode - The Home Assistant climate fan_mode attribute value.
+ * @param {string[]} [fanModes] - The climate entity fan_modes attribute, used for positional ranking.
+ * @returns {FanControl.FanMode | null} The Matter fan mode, or null when the value cannot be mapped.
+ */
+export function matterFanModeFromHassClimateFanMode(fanMode: string, fanModes?: string[]): FanControl.FanMode | null {
+  if (!isValidString(fanMode, 1)) return null;
+  const mode = fanMode.toLowerCase();
+  if (mode === 'auto' || mode === 'smart') return FanControl.FanMode.Auto;
+  if (mode === 'off') return FanControl.FanMode.Off;
+  if (mode === 'low') return FanControl.FanMode.Low;
+  if (mode === 'medium' || mode === 'mid') return FanControl.FanMode.Medium;
+  if (mode === 'high') return FanControl.FanMode.High;
+  const speeds = getClimateSpeedFanModes(fanModes).map((m) => m.toLowerCase());
+  const index = speeds.indexOf(mode);
+  if (index === -1) return null;
+  if (speeds.length === 1) return FanControl.FanMode.High;
+  const ratio = index / (speeds.length - 1);
+  if (ratio <= 1 / 3) return FanControl.FanMode.Low;
+  if (ratio <= 2 / 3) return FanControl.FanMode.Medium;
+  return FanControl.FanMode.High;
+}
+
+/**
+ * Converts a Matter FanControl.FanMode to a Home Assistant climate fan mode string.
+ *
+ * Canonical names are preferred when present in the entity fan_modes; otherwise the ordered list of
+ * speed fan modes is sampled positionally (Low = first, Medium = middle, High = last). Auto, Smart and
+ * On map to the auto fan mode when available and fall back to the highest speed.
+ *
+ * @param {FanControl.FanMode} fanMode - The Matter fan mode written by the controller.
+ * @param {string[]} [fanModes] - The climate entity fan_modes attribute.
+ * @returns {string | null} The Home Assistant fan mode to send with climate.set_fan_mode, or null when
+ * the value cannot be mapped (FanControl.FanMode.Off returns null: the caller turns the entity off).
+ */
+export function hassClimateFanModeFromMatterFanMode(fanMode: FanControl.FanMode, fanModes?: string[]): string | null {
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  if (!isValidNumber(fanMode, FanControl.FanMode.Off, FanControl.FanMode.Smart)) return null;
+  if (fanMode === FanControl.FanMode.Off) return null;
+  if (!isValidArray(fanModes, 1)) return null;
+  const lower = fanModes.map((mode) => mode.toLowerCase());
+  const speeds = getClimateSpeedFanModes(fanModes);
+  const findCanonical = (...names: string[]): string | undefined => {
+    for (const name of names) {
+      const index = lower.indexOf(name);
+      if (index !== -1) return fanModes[index];
+    }
+    return undefined;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  if (fanMode === FanControl.FanMode.Auto || fanMode === FanControl.FanMode.Smart || fanMode === FanControl.FanMode.On) {
+    return findCanonical('auto', 'smart') ?? (speeds.length > 0 ? speeds[speeds.length - 1] : null);
+  }
+  if (speeds.length === 0) return null;
+  if (fanMode === FanControl.FanMode.Low) return findCanonical('low') ?? speeds[0];
+  if (fanMode === FanControl.FanMode.Medium) return findCanonical('medium', 'mid') ?? speeds[Math.floor((speeds.length - 1) / 2)];
+  return findCanonical('high') ?? speeds[speeds.length - 1];
+}
+
+/**
+ * Converts a Home Assistant climate fan mode string to a Matter FanControl percent value.
+ *
+ * The percent is derived from the position of the fan mode in the ordered list of speed fan modes.
+ *
+ * @param {string} fanMode - The Home Assistant climate fan_mode attribute value.
+ * @param {string[]} [fanModes] - The climate entity fan_modes attribute.
+ * @returns {number | null} The percent value (1-100), or null when the fan mode is auto or cannot be mapped.
+ */
+export function matterFanPercentFromHassClimateFanMode(fanMode: string, fanModes?: string[]): number | null {
+  if (!isValidString(fanMode, 1)) return null;
+  const speeds = getClimateSpeedFanModes(fanModes).map((m) => m.toLowerCase());
+  const index = speeds.indexOf(fanMode.toLowerCase());
+  if (index === -1) return null;
+  return Math.round(((index + 1) / speeds.length) * 100);
+}
+
+/**
+ * Converts a Matter FanControl percent value to a Home Assistant climate fan mode string.
+ *
+ * The percent range is split evenly across the ordered list of speed fan modes.
+ *
+ * @param {number} percent - The percent value (1-100) written by the controller.
+ * @param {string[]} [fanModes] - The climate entity fan_modes attribute.
+ * @returns {string | null} The Home Assistant fan mode to send with climate.set_fan_mode, or null when
+ * the value cannot be mapped (percent 0 returns null: the caller turns the entity off).
+ */
+export function hassClimateFanModeFromMatterFanPercent(percent: number, fanModes?: string[]): string | null {
+  if (!isValidNumber(percent, 1, 100)) return null;
+  const speeds = getClimateSpeedFanModes(fanModes);
+  if (speeds.length === 0) return null;
+  const index = Math.min(speeds.length - 1, Math.ceil((percent / 100) * speeds.length) - 1);
+  return speeds[index];
+}
+
 /** Update Home Assistant state to Matterbridge device states */
 // prettier-ignore
 export const hassUpdateStateConverter: { domain: string; state: string; clusterId: ClusterId | undefined; attribute: string; value: any }[] = [
@@ -349,6 +459,16 @@ export const hassUpdateStateConverter: { domain: string; state: string; clusterI
     { domain: 'climate', state: 'cool', clusterId: Thermostat.id, attribute: 'systemMode', value: Thermostat.SystemMode.Cool },
     { domain: 'climate', state: 'heat_cool', clusterId: Thermostat.id, attribute: 'systemMode', value: Thermostat.SystemMode.Auto },
     { domain: 'climate', state: 'auto', clusterId: undefined, attribute: '', value: null }, // 'auto' is not updated directly
+    { domain: 'climate', state: 'dry', clusterId: Thermostat.id, attribute: 'systemMode', value: Thermostat.SystemMode.Dry },
+    { domain: 'climate', state: 'fan_only', clusterId: Thermostat.id, attribute: 'systemMode', value: Thermostat.SystemMode.FanOnly },
+    // The OnOff rows only apply to climate entities exposed as air conditioner (Dead Front OnOff cluster).
+    { domain: 'climate', state: 'off', clusterId: OnOff.id, attribute: 'onOff', value: false },
+    { domain: 'climate', state: 'heat', clusterId: OnOff.id, attribute: 'onOff', value: true },
+    { domain: 'climate', state: 'cool', clusterId: OnOff.id, attribute: 'onOff', value: true },
+    { domain: 'climate', state: 'heat_cool', clusterId: OnOff.id, attribute: 'onOff', value: true },
+    { domain: 'climate', state: 'auto', clusterId: OnOff.id, attribute: 'onOff', value: true },
+    { domain: 'climate', state: 'dry', clusterId: OnOff.id, attribute: 'onOff', value: true },
+    { domain: 'climate', state: 'fan_only', clusterId: OnOff.id, attribute: 'onOff', value: true },
 
     { domain: 'valve', state: 'opening', clusterId: ValveConfigurationAndControl.id, attribute: 'currentState', value: ValveConfigurationAndControl.ValveState.Transitioning },
     { domain: 'valve', state: 'open', clusterId: ValveConfigurationAndControl.id, attribute: 'currentState', value: ValveConfigurationAndControl.ValveState.Open },
@@ -432,6 +552,10 @@ export const hassUpdateAttributeConverter: { domain: string; with: string; clust
     { domain: 'climate', with: 'target_temp_high',    clusterId: Thermostat.id, attribute: 'occupiedCoolingSetpoint', converter: (value: number, state: HassState) => (isValidNumber(value) && (state.attributes?.hvac_modes?.includes(HVACMode.HEAT_COOL) || state.attributes?.hvac_modes?.includes(HVACMode.COOL)) ? Math.round(temp(value, HomeAssistant.hassConfig?.unit_system?.temperature) * 100) : null) },
     { domain: 'climate', with: 'target_temp_low',     clusterId: Thermostat.id, attribute: 'occupiedHeatingSetpoint', converter: (value: number, state: HassState) => (isValidNumber(value) && (state.attributes?.hvac_modes?.includes(HVACMode.HEAT_COOL) || state.attributes?.hvac_modes?.includes(HVACMode.HEAT)) ? Math.round(temp(value, HomeAssistant.hassConfig?.unit_system?.temperature) * 100) : null) },
     { domain: 'climate', with: 'current_temperature', clusterId: Thermostat.id, attribute: 'localTemperature', converter: (value: number) => (isValidNumber(value) ? Math.round(temp(value, HomeAssistant.hassConfig?.unit_system?.temperature) * 100) : null) },
+    // The FanControl rows only apply to climate entities exposed as air conditioner with a Fan Control cluster.
+    { domain: 'climate', with: 'fan_mode',            clusterId: FanControl.id, attribute: 'fanMode', converter: (value: string, state: HassState) => matterFanModeFromHassClimateFanMode(value, state.attributes['fan_modes']) },
+    { domain: 'climate', with: 'fan_mode',            clusterId: FanControl.id, attribute: 'percentCurrent', converter: (value: string, state: HassState) => matterFanPercentFromHassClimateFanMode(value, state.attributes['fan_modes']) },
+    { domain: 'climate', with: 'fan_mode',            clusterId: FanControl.id, attribute: 'percentSetting', converter: (value: string, state: HassState) => matterFanPercentFromHassClimateFanMode(value, state.attributes['fan_modes']) },
 
     { domain: 'valve', with: 'current_position', clusterId: ValveConfigurationAndControl.id, attribute: 'currentLevel', converter: (value: number) => (isValidNumber(value, 0, 100) ? Math.round(value) : null) },
   ];
@@ -570,6 +694,11 @@ export const hassCommandConverter: { command: CommandHandlers; domain: string; s
     { command: 'changeToMode',            domain: 'input_select', service: 'select_option', converter: (request, attributes, state) => { return getSelectOptionFromMode(request, state) } },
     { command: 'changeToMode',            domain: 'select', service: 'select_option', converter: (request, attributes, state) => { return getSelectOptionFromMode(request, state) }  },
 
+    // The climate on/off/toggle commands only apply to climate entities exposed as air conditioner (Dead Front OnOff cluster).
+    { command: 'on',                      domain: 'climate', service: 'turn_on' },
+    { command: 'off',                     domain: 'climate', service: 'turn_off' },
+    { command: 'toggle',                  domain: 'climate', service: 'toggle' },
+
     { command: 'on',                      domain: 'media_player', service: 'turn_on' },
     { command: 'off',                     domain: 'media_player', service: 'turn_off' },
     { command: 'play',                    domain: 'media_player', service: 'media_play' },
@@ -584,7 +713,7 @@ export const hassCommandConverter: { command: CommandHandlers; domain: string; s
  * Returning null will send turn_off service to Home Assistant instead of turn_on with attributes.
  */
 // prettier-ignore
-export const hassSubscribeConverter: { domain: string; service: string; with: string; clusterId: ClusterId; attribute: string; converter?: (value: number) => any }[] = [
+export const hassSubscribeConverter: { domain: string; service: string; with: string; clusterId: ClusterId; attribute: string; converter?: (value: any, state?: HassState) => any }[] = [
     { domain: 'fan',      service: 'turn_on',         with: 'preset_mode',  clusterId: FanControl.id,  attribute: 'fanMode', converter: (value: FanControl.FanMode) => {
       // eslint-disable-next-line @typescript-eslint/no-deprecated
       if( isValidNumber(value, FanControl.FanMode.Low, FanControl.FanMode.Smart) ) {
@@ -612,4 +741,7 @@ export const hassSubscribeConverter: { domain: string; service: string; with: st
     }},
     { domain: 'climate',  service: 'set_temperature', with: 'temperature',  clusterId: Thermostat.id,  attribute: 'occupiedHeatingSetpoint', converter: (value) => { return tempToFahrenheit(value / 100) } },
     { domain: 'climate',  service: 'set_temperature', with: 'temperature',  clusterId: Thermostat.id,  attribute: 'occupiedCoolingSetpoint', converter: (value) => { return tempToFahrenheit(value / 100) } },
+    // The FanControl rows only apply to climate entities exposed as air conditioner with a Fan Control cluster.
+    { domain: 'climate',  service: 'set_fan_mode',    with: 'fan_mode',     clusterId: FanControl.id,  attribute: 'fanMode', converter: (value: FanControl.FanMode, state?: HassState) => hassClimateFanModeFromMatterFanMode(value, state?.attributes['fan_modes']) },
+    { domain: 'climate',  service: 'set_fan_mode',    with: 'fan_mode',     clusterId: FanControl.id,  attribute: 'percentSetting', converter: (value: number, state?: HassState) => hassClimateFanModeFromMatterFanPercent(value, state?.attributes['fan_modes']) },
   ]

--- a/src/module.ts
+++ b/src/module.ts
@@ -95,6 +95,8 @@ export interface HomeAssistantPlatformConfig extends PlatformConfig {
   enableServerRvc: boolean;
   discardHiddenEntities: boolean;
   virtualControlLabel: string;
+  /** Expose climate entities with this label name as Room Air Conditioner devices instead of Thermostat devices */
+  airConditionerLabel: string;
 }
 
 /**
@@ -230,6 +232,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       this.config.enableServerRvc = isValidBoolean(this.config.enableServerRvc) ? this.config.enableServerRvc : true;
       this.config.discardHiddenEntities = isValidBoolean(this.config.discardHiddenEntities) ? this.config.discardHiddenEntities : false;
       this.config.virtualControlLabel = isValidString(this.config.virtualControlLabel, 1) ? this.config.virtualControlLabel : '';
+      this.config.airConditionerLabel = isValidString(this.config.airConditionerLabel, 1) ? this.config.airConditionerLabel : '';
     }
 
     // Initialize air quality regex from config or use default
@@ -1221,7 +1224,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       `${db}Subscribed attribute ${hk}${getClusterNameById(hassSubscribe.clusterId)}${db}:${hk}${hassSubscribe.attribute}${db} on endpoint ${or}${endpoint?.maybeId}${db}:${or}${endpoint?.maybeNumber}${db} ` +
         `changed from ${YELLOW}${typeof oldValue === 'object' ? debugStringify(oldValue) : oldValue}${db} to ${YELLOW}${typeof newValue === 'object' ? debugStringify(newValue) : newValue}${db}`,
     );
-    const value = hassSubscribe.converter ? hassSubscribe.converter(newValue) : newValue;
+    const value = hassSubscribe.converter ? hassSubscribe.converter(newValue, state) : newValue;
     // istanbul ignore else
     if (hassSubscribe.converter)
       endpoint.log.debug(`Converter: ${typeof newValue === 'object' ? debugStringify(newValue) : newValue} => ${typeof value === 'object' ? debugStringify(value) : value}`);
@@ -1355,6 +1358,11 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
       const hassUpdateState = hassUpdateStateConverter.filter((updateState) => updateState.domain === domain && updateState.state === new_state.state);
       if (hassUpdateState.length > 0) {
         for (const update of hassUpdateState) {
+          // Skip the update if the endpoint doesn't have the cluster attribute (i.e. OnOff rows for climate entities not exposed as air conditioner).
+          if (update.clusterId !== undefined && !endpoint.hasAttributeServer(update.clusterId, update.attribute)) {
+            endpoint.log.debug(`Update state ${CYAN}${domain}${db}:${CYAN}${new_state.state}${db} skipped: no attribute ${CYAN}${update.attribute}${db} for entity ${entityId}`);
+            continue;
+          }
           // istanbul ignore else
           if (update.clusterId !== undefined) await endpoint.setAttribute(update.clusterId, update.attribute, update.value, matterbridgeDevice.log);
         }
@@ -1378,6 +1386,11 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
             break;
           }
           // console.error('- processing update attribute', update.with, 'value', new_state.attributes[update.with]);
+          // Skip the update if the endpoint doesn't have the cluster attribute (i.e. FanControl rows for climate entities not exposed as air conditioner).
+          if (!endpoint.hasAttributeServer(update.clusterId, update.attribute)) {
+            endpoint.log.debug(`Update attribute ${CYAN}${update.with}${db} skipped: no attribute ${CYAN}${update.attribute}${db} for entity ${entityId}`);
+            continue;
+          }
           // @ts-expect-error: dynamic property access for Home Assistant state attribute
           const value = new_state.attributes[update.with];
           if (value !== null) {

--- a/src/mutableDevice.test.ts
+++ b/src/mutableDevice.test.ts
@@ -9,6 +9,7 @@ import path from 'node:path';
 
 import { jest } from '@jest/globals';
 import {
+  airConditioner,
   bridgedNode,
   colorTemperatureLight,
   colorTemperatureSwitch,
@@ -64,6 +65,7 @@ import {
   RelativeHumidityMeasurement,
   SmokeCoAlarm,
   TemperatureMeasurement,
+  Thermostat,
 } from 'matterbridge/matter/clusters';
 
 import { MutableDevice } from './mutableDevice.js';
@@ -1335,6 +1337,78 @@ describe('MutableDevice', () => {
     expect(childEndpoint.getAllClusterServerNames()).toEqual(['descriptor', 'matterbridge', 'onOff', 'powerSource']);
 
     await addDevice(aggregator, device);
+    mutableDevice.destroy();
+  });
+
+  test('should removeDeviceTypes', () => {
+    const mutableDevice = new MutableDevice(mockMatterbridge, 'Test Device removeDeviceTypes');
+    mutableDevice.addDeviceTypes('', bridgedNode, thermostatDevice);
+    expect(mutableDevice.get().deviceTypes).toContain(thermostatDevice);
+    mutableDevice.removeDeviceTypes('', thermostatDevice);
+    expect(mutableDevice.get().deviceTypes).not.toContain(thermostatDevice);
+    expect(mutableDevice.get().deviceTypes).toContain(bridgedNode);
+    // Removing a device type that is not present is a no-op
+    mutableDevice.removeDeviceTypes('', thermostatDevice);
+    expect(mutableDevice.get().deviceTypes).toHaveLength(1);
+    mutableDevice.destroy();
+  });
+
+  test('should create a room air conditioner device', async () => {
+    const mutableDevice = new MutableDevice(mockMatterbridge, 'Test Device Air Conditioner');
+    mutableDevice.addDeviceTypes('', bridgedNode, airConditioner);
+    mutableDevice.addClusterServerDeadFrontOnOff('', true);
+    mutableDevice.addClusterServerCoolingThermostat('', 24.3, 22, 16, 31);
+    mutableDevice.addClusterServerBaseFanControl('', FanControl.FanMode.Auto, FanControl.FanModeSequence.OffLowMedHighAuto, 50, 50);
+
+    device = mutableDevice.create();
+    expect(device).toBeDefined();
+    expect(device.deviceTypes.get(airConditioner.code)).toBeDefined();
+    expect(device.deviceTypes.get(thermostatDevice.code)).toBeUndefined();
+    expect(device.getAllClusterServerNames()).toEqual(expect.arrayContaining(['onOff', 'thermostat', 'fanControl', 'identify']));
+
+    await addDevice(aggregator, device);
+
+    // Dead Front OnOff cluster
+    expect(device.getAttribute(OnOff.id, 'featureMap')).toEqual(expect.objectContaining({ lighting: false, deadFrontBehavior: true, offOnly: false }));
+    expect(device.getAttribute(OnOff.id, 'onOff')).toBe(true);
+    // Cooling only Thermostat cluster
+    expect(device.getAttribute(Thermostat.id, 'featureMap')).toEqual(expect.objectContaining({ heating: false, cooling: true, autoMode: false }));
+    expect(device.getAttribute(Thermostat.id, 'controlSequenceOfOperation')).toBe(Thermostat.ControlSequenceOfOperation.CoolingOnly);
+    expect(device.getAttribute(Thermostat.id, 'systemMode')).toBe(Thermostat.SystemMode.Cool);
+    expect(device.getAttribute(Thermostat.id, 'occupiedCoolingSetpoint')).toBe(2200);
+    // Base FanControl cluster with the Auto feature
+    expect(device.getAttribute(FanControl.id, 'featureMap')).toEqual(
+      expect.objectContaining({ multiSpeed: false, auto: true, rocking: false, wind: false, airflowDirection: false }),
+    );
+    expect(device.getAttribute(FanControl.id, 'fanModeSequence')).toBe(FanControl.FanModeSequence.OffLowMedHighAuto);
+    expect(device.getAttribute(FanControl.id, 'fanMode')).toBe(FanControl.FanMode.Auto);
+    expect(device.getAttribute(FanControl.id, 'percentSetting')).toBe(50);
+
+    // The dry and fan_only climate states write the Dry / FanOnly system modes on the (cooling only) thermostat
+    await expect(device.setAttribute(Thermostat.id, 'systemMode', Thermostat.SystemMode.Dry, device.log)).resolves.toBe(true);
+    expect(device.getAttribute(Thermostat.id, 'systemMode')).toBe(Thermostat.SystemMode.Dry);
+    await expect(device.setAttribute(Thermostat.id, 'systemMode', Thermostat.SystemMode.FanOnly, device.log)).resolves.toBe(true);
+    expect(device.getAttribute(Thermostat.id, 'systemMode')).toBe(Thermostat.SystemMode.FanOnly);
+
+    mutableDevice.destroy();
+  });
+
+  test('should create a base fan control without the auto feature', async () => {
+    const mutableDevice = new MutableDevice(mockMatterbridge, 'Test Device Air Conditioner No Auto');
+    mutableDevice.addDeviceTypes('', bridgedNode, airConditioner);
+    mutableDevice.addClusterServerDeadFrontOnOff('', false);
+    mutableDevice.addClusterServerCoolingThermostat('', 24.3, 22, 16, 31);
+    mutableDevice.addClusterServerBaseFanControl('', FanControl.FanMode.Low, FanControl.FanModeSequence.OffLowMedHigh, 33, 33);
+
+    device = mutableDevice.create();
+    expect(device).toBeDefined();
+    await addDevice(aggregator, device);
+
+    expect(device.getAttribute(OnOff.id, 'onOff')).toBe(false);
+    expect(device.getAttribute(FanControl.id, 'featureMap')).toEqual(expect.objectContaining({ auto: false }));
+    expect(device.getAttribute(FanControl.id, 'fanModeSequence')).toBe(FanControl.FanModeSequence.OffLowMedHigh);
+    expect(device.getAttribute(FanControl.id, 'fanMode')).toBe(FanControl.FanMode.Low);
+
     mutableDevice.destroy();
   });
 });

--- a/src/mutableDevice.ts
+++ b/src/mutableDevice.ts
@@ -384,6 +384,22 @@ export class MutableDevice {
   }
 
   /**
+   * Removes one or more Matter device types from the specified endpoint.
+   *
+   * Device types are matched by their device type code. Removing a device type that is not
+   * present is a no-op.
+   *
+   * @param {string} endpoint - Endpoint identifier ('' for main endpoint).
+   * @param {...DeviceTypeDefinition[]} deviceTypes - Device type definitions to remove.
+   * @returns {this} The current instance for chaining.
+   */
+  removeDeviceTypes(endpoint: string, ...deviceTypes: DeviceTypeDefinition[]): this {
+    const device = this.initializeEndpoint(endpoint);
+    device.deviceTypes = device.deviceTypes.filter((deviceType) => !deviceTypes.some((removed) => removed.code === deviceType.code));
+    return this;
+  }
+
+  /**
    * Adds one or more cluster server IDs (simple form) to the specified endpoint.
    *
    * If a full cluster server object for the same ID is later added via
@@ -748,6 +764,61 @@ export class MutableDevice {
           airflowDirection, // Writable attribute
         },
       ),
+    );
+    return this;
+  }
+
+  /**
+   * Adds a base Fan Control cluster server (no Rocking, Wind, Step or AirflowDirection features) to the endpoint.
+   *
+   * The Auto feature is enabled only when the provided fan mode sequence includes Auto.
+   *
+   * @param {string} endpoint - Endpoint identifier ('' for main endpoint).
+   * @param {FanControl.FanMode} fanMode - Initial fan mode.
+   * @param {FanControl.FanModeSequence} fanModeSequence - Fixed fan mode sequence.
+   * @param {number} percentSetting - Initial percent setting (0-100).
+   * @param {number} percentCurrent - Initial percent current (0-100).
+   * @returns {this} The current instance for chaining.
+   */
+  addClusterServerBaseFanControl(
+    endpoint: string,
+    fanMode: FanControl.FanMode = FanControl.FanMode.Off,
+    fanModeSequence: FanControl.FanModeSequence = FanControl.FanModeSequence.OffLowMedHighAuto,
+    percentSetting: number = 0,
+    percentCurrent: number = 0,
+  ): this {
+    const device = this.initializeEndpoint(endpoint);
+    const hasAuto =
+      fanModeSequence === FanControl.FanModeSequence.OffLowMedHighAuto ||
+      fanModeSequence === FanControl.FanModeSequence.OffLowHighAuto ||
+      fanModeSequence === FanControl.FanModeSequence.OffHighAuto;
+    device.clusterServersObjs.push(
+      getClusterServerObj(FanControl.id, hasAuto ? MatterbridgeFanControlServer.with(FanControl.Feature.Auto) : MatterbridgeFanControlServer.with(), {
+        fanMode, // Writable and persistent attribute
+        fanModeSequence, // Fixed attribute
+        percentSetting, // Writable attribute
+        percentCurrent,
+      }),
+    );
+    return this;
+  }
+
+  /**
+   * Adds an OnOff cluster server with the Dead Front feature to the endpoint.
+   *
+   * The Dead Front OnOff cluster is required by appliance device types like the Room Air Conditioner:
+   * when turned off the device shows a "dead front" (the other clusters report null/default values).
+   *
+   * @param {string} endpoint - Endpoint identifier ('' for main endpoint).
+   * @param {boolean} onOff - Initial on/off state.
+   * @returns {this} The current instance for chaining.
+   */
+  addClusterServerDeadFrontOnOff(endpoint: string, onOff: boolean): this {
+    const device = this.initializeEndpoint(endpoint);
+    device.clusterServersObjs.push(
+      getClusterServerObj(OnOff.id, MatterbridgeOnOffServer.with(OnOff.Feature.DeadFrontBehavior), {
+        onOff,
+      }),
     );
     return this;
   }


### PR DESCRIPTION
# feat: expose labeled climate entities as Room Air Conditioner (Matter 1.2, 0x0072)

## Motivation

Climate entities backing a room air conditioner are currently exposed as a Thermostat device (`0x0301`). This works, but it loses the appliance semantics Matter 1.2 introduced with the **Room Air Conditioner** device type (`0x0072`): a single endpoint composing On/Off (Dead Front), Thermostat, and Fan Control. It also means the entity's fan (`fan_modes`) is not exposed at all, and `dry`/`fan_only` states are unmapped.

This PR adds an opt-in path to expose such entities as a true Room Air Conditioner, following the plugin's existing label-based selection pattern (`splitByLabel`, `virtualControlLabel`).

## What's new

**New config option `airConditionerLabel`** (string, default `""`, same pattern as `virtualControlLabel`): climate entities carrying this Home Assistant label are exposed as a Room Air Conditioner device instead of a Thermostat device.

For a labeled climate entity:

- The `thermostatDevice` device type is replaced by `airConditioner` (`0x0072`) on the endpoint.
- The **Dead Front OnOff cluster** (mandatory for `0x0072`) is added, mapped to `climate.turn_on` / `climate.turn_off` / `climate.toggle`, and reflects the entity state (`off` → OnOff false, any active state → true).
- When the entity has `fan_modes`, a **base Fan Control cluster** is added (Auto feature only when the entity has an `auto`/`smart` fan mode). Controller writes to `fanMode` or `percentSetting` call `climate.set_fan_mode`; entity `fan_mode` changes update `fanMode`, `percentSetting`, and `percentCurrent`.
- The `dry` and `fan_only` states map to the `Dry` / `FanOnly` system modes.
- The existing `hvac_modes`-derived Thermostat feature selection is unchanged: cooling-only units keep a cooling-only Thermostat cluster (`FeatureMap` COOL, `ControlSequenceOfOperation` CoolingOnly), so controllers show no phantom Heat mode.

Unlabeled climate entities are completely unaffected.

## Fan mode mapping

Home Assistant climate `fan_modes` lists are free-form (e.g. Midea: `silent, low, medium, high, full, auto`). Four new exported helpers map them to/from Matter `FanControl.FanMode` and percent values: canonical names (`auto`, `smart`, `off`, `low`, `medium`, `mid`, `high`) match first, anything else is ranked by its position in the ordered list of speed modes. `FanControl.FanMode.Off` and percent 0 return `null`, which the subscribe handler already treats as `turn_off`.

## Supporting changes

- `MutableDevice` gains `removeDeviceTypes()`, `addClusterServerDeadFrontOnOff()` and `addClusterServerBaseFanControl()`.
- `updateHandler` now skips converter rows whose cluster attribute is absent on the endpoint (debug log instead of a `setAttribute` error) — this is what keeps the new domain-wide climate rows inert for plain thermostats, and it silences pre-existing impossible writes generally.
- The `hassSubscribeConverter` converter signature gains an optional `state` argument (needed to resolve fan mode names against the entity's `fan_modes`); existing converters are unaffected.

## Testing

- New jest tests in `converters.test.ts` (fan mode mapping helpers), `control.entity.test.ts` (labeled/unlabeled climate paths), and `mutableDevice.test.ts` (Room AC endpoint built against a real matter.js server node: asserts DeviceTypeList `0x0072`, OnOff FeatureMap `deadFrontBehavior`, Thermostat FeatureMap cooling-only + `ControlSequenceOfOperation` CoolingOnly, FanControl features, and that `Dry`/`FanOnly` systemMode writes are accepted on a cooling-only thermostat).
- Full suite: no regressions (failure set before/after is identical on my machine against matterbridge main built from source; the pre-existing failures are device-type-name expectation skew unrelated to this change).
- Verified end-to-end on real hardware: two Midea cooling-only ACs (via `midea_ac_lan`) exposed through this branch, commissioned from a matter.js controller — DeviceTypeList `[0x0072]`, Thermostat FeatureMap `0x02`, `ControlSequenceOfOperation=0`; setpoint/fan/on-off writes propagate to the physical units.

## Docs

README (supported domains table + footnote), config schema description, and CHANGELOG entry included.
