### PR TITLE
feat: add native support for Home Assistant humidifier domain

### DIFF
--- a/src/converters.ts
+++ b/src/converters.ts
@@ -356,6 +356,9 @@ export const hassUpdateStateConverter: { domain: string; state: string; clusterI
     { domain: 'climate', state: 'heat_cool', clusterId: Thermostat.id, attribute: 'systemMode', value: Thermostat.SystemMode.Auto },
     { domain: 'climate', state: 'auto', clusterId: undefined, attribute: '', value: null }, // 'auto' is not updated directly
 
+    { domain: 'humidifier', state: 'on', clusterId: OnOff.id, attribute: 'onOff', value: true },
+    { domain: 'humidifier', state: 'off', clusterId: OnOff.id, attribute: 'onOff', value: false },
+
     { domain: 'valve', state: 'opening', clusterId: ValveConfigurationAndControl.id, attribute: 'currentState', value: ValveConfigurationAndControl.ValveState.Transitioning },
     { domain: 'valve', state: 'open', clusterId: ValveConfigurationAndControl.id, attribute: 'currentState', value: ValveConfigurationAndControl.ValveState.Open },
     { domain: 'valve', state: 'closing', clusterId: ValveConfigurationAndControl.id, attribute: 'currentState', value: ValveConfigurationAndControl.ValveState.Transitioning },
@@ -440,6 +443,9 @@ export const hassUpdateAttributeConverter: { domain: string; with: string; clust
     { domain: 'climate', with: 'target_temp_low',     clusterId: Thermostat.id, attribute: 'occupiedHeatingSetpoint', converter: (value: number, state: HassState) => (isValidNumber(value) && (state.attributes?.hvac_modes?.includes(HVACMode.HEAT_COOL) || state.attributes?.hvac_modes?.includes(HVACMode.HEAT)) ? Math.round(temp(value, HomeAssistant.hassConfig?.unit_system?.temperature) * 100) : null) },
     { domain: 'climate', with: 'current_temperature', clusterId: Thermostat.id, attribute: 'localTemperature', converter: (value: number) => (isValidNumber(value) ? Math.round(temp(value, HomeAssistant.hassConfig?.unit_system?.temperature) * 100) : null) },
 
+    { domain: 'humidifier', with: 'humidity',         clusterId: LevelControl.id, attribute: 'currentLevel', converter: (value: number) => (isValidNumber(value, 0, 100) ? Math.round(value * 2.54) : null) },
+    { domain: 'humidifier', with: 'current_humidity', clusterId: RelativeHumidityMeasurement.id, attribute: 'measuredValue', converter: (value: number) => (isValidNumber(value, 0, 100) ? Math.round(value * 100) : null) },
+
     { domain: 'valve', with: 'current_position', clusterId: ValveConfigurationAndControl.id, attribute: 'currentLevel', converter: (value: number) => (isValidNumber(value, 0, 100) ? Math.round(value) : null) },
   ];
 
@@ -460,6 +466,9 @@ export const hassDomainConverter: { domain: string; withAttribute?: string; devi
     { domain: 'fan',                                    deviceType: fan,                    clusterId: FanControl.id },
     { domain: 'cover',                                  deviceType: windowCovering,         clusterId: WindowCovering.id },
     { domain: 'climate',                                deviceType: thermostat,             clusterId: Thermostat.id },
+    { domain: 'humidifier',                             deviceType: onOffPlugInUnit,        clusterId: OnOff.id },
+    { domain: 'humidifier', withAttribute: 'humidity',  deviceType: onOffPlugInUnit,        clusterId: LevelControl.id },
+    { domain: 'humidifier', withAttribute: 'current_humidity', deviceType: humiditySensor, clusterId: RelativeHumidityMeasurement.id },
     { domain: 'valve',                                  deviceType: waterValve,             clusterId: ValveConfigurationAndControl.id },
     { domain: 'vacuum',                                 deviceType: roboticVacuumCleaner,   clusterId: RvcRunMode.id },
     { domain: 'vacuum',                                 deviceType: roboticVacuumCleaner,   clusterId: RvcCleanMode.id },
@@ -584,6 +593,9 @@ export const hassCommandConverter: { command: CommandHandlers; domain: string; s
     { command: 'stop',                    domain: 'media_player', service: 'media_stop' },
     { command: 'previous',                domain: 'media_player', service: 'media_previous_track' },
     { command: 'next',                    domain: 'media_player', service: 'media_next_track' },
+
+    { command: 'on',                      domain: 'humidifier', service: 'turn_on' },
+    { command: 'off',                     domain: 'humidifier', service: 'turn_off' },
   ];
 
 /**
@@ -620,4 +632,6 @@ export const hassSubscribeConverter: { domain: string; service: string; with: st
     }},
     { domain: 'climate',  service: 'set_temperature', with: 'temperature',  clusterId: Thermostat.id,  attribute: 'occupiedHeatingSetpoint', converter: (value) => { return tempToFahrenheit(value / 100) } },
     { domain: 'climate',  service: 'set_temperature', with: 'temperature',  clusterId: Thermostat.id,  attribute: 'occupiedCoolingSetpoint', converter: (value) => { return tempToFahrenheit(value / 100) } },
+
+    { domain: 'humidifier', service: 'set_humidity',  with: 'humidity',     clusterId: LevelControl.id, attribute: 'currentLevel', converter: (value: number) => Math.round(value / 2.54) },
   ]

--- a/src/homeAssistant.ts
+++ b/src/homeAssistant.ts
@@ -601,6 +601,22 @@ export interface HassStateClimateAttributes {
   supported_features?: ClimateEntityFeature; // Supported features of the climate entity
 }
 
+/**
+ * Interface representing the attributes of a Home Assistant humidifier entity's state.
+ */
+export interface HassStateHumidifierAttributes {
+  humidity: number | null; // Target humidity setting
+  current_humidity: number | null; // Current humidity
+  min_humidity: number; // Minimum humidity setting
+  max_humidity: number; // Maximum humidity setting
+  target_humidity_step?: number;
+  available_modes?: string[];
+  mode?: string | null;
+  action?: string | null;
+  device_class?: 'humidifier' | 'dehumidifier' | null;
+  supported_features?: number;
+}
+
 /** Supported features of the climate entity.*/
 export enum ClimateEntityFeature {
   TARGET_TEMPERATURE = 1,

--- a/src/module.ts
+++ b/src/module.ts
@@ -160,7 +160,7 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
   /** Supported helper domains */
   readonly supportedHelpersDomains = ['automation', 'scene', 'script', 'input_boolean', 'input_button'];
   /** Supported core domains */
-  readonly supportedCoreDomains = ['switch', 'light', 'lock', 'fan', 'cover', 'climate', 'valve', 'vacuum', 'remote', 'input_select', 'select', 'media_player']; // 'input_select' is an helper but we support it like core
+  readonly supportedCoreDomains = ['switch', 'light', 'lock', 'fan', 'cover', 'climate', 'humidifier', 'valve', 'vacuum', 'remote', 'input_select', 'select', 'media_player']; // 'input_select' is an helper but we support it like core
   /** Supported other domains */
   readonly supportedOtherDomains = ['sensor', 'binary_sensor', 'event', 'button'];
   /** All supported domains */

--- a/vitest/converters.test.ts
+++ b/vitest/converters.test.ts
@@ -244,6 +244,14 @@ describe('HassPlatform converters', () => {
         expect(converter.converter(100, {} as HassState)).toBe(100);
         expect(converter.converter(-1, {} as HassState)).toBe(null);
       }
+      if (converter.domain === 'humidifier' && converter.with === 'humidity') {
+        expect(converter.converter(50, {} as HassState)).toBe(127);
+        expect(converter.converter('50', {} as HassState)).toBe(null);
+      }
+      if (converter.domain === 'humidifier' && converter.with === 'current_humidity') {
+        expect(converter.converter(48, {} as HassState)).toBe(4800);
+        expect(converter.converter('48', {} as HassState)).toBe(null);
+      }
     });
   });
 
@@ -439,6 +447,9 @@ describe('HassPlatform converters', () => {
           } as HassUnitSystem,
         } as HassConfig;
         expect(converter.converter(1000)).toBe(10);
+      }
+      if (converter.domain === 'humidifier' && converter.service === 'set_humidity' && converter.converter) {
+        expect(converter.converter(127)).toBe(50);
       }
     });
   });


### PR DESCRIPTION
## Summary
Adds native domain support for Home Assistant `humidifier` entities (`humidifier.*`) to `matterbridge-hass`.

## Changes Made
- **src/module.ts**: Added `'humidifier'` to `supportedCoreDomains`.
- **src/homeAssistant.ts**: Defined `HassStateHumidifierAttributes` interface for humidifier state attributes (`humidity`, `current_humidity`, `min_humidity`, `max_humidity`, `target_humidity_step`, `device_class`).
- **src/converters.ts**:
  - Mapped `on`/`off` states to Matter `OnOff` cluster.
  - Mapped `humidity` (target setpoint) to Matter `LevelControl` and `current_humidity` to `RelativeHumidityMeasurement`.
  - Mapped domain `'humidifier'` to `onOffPlugInUnit` and `humiditySensor`.
  - Added service call converters for `humidifier.turn_on`, `humidifier.turn_off`, and `humidifier.set_humidity`.

## Motivation
Currently, Home Assistant `humidifier` entities are ignored during device discovery unless manually wrapped in custom helpers. This PR enables `humidifier.*` entities to be exposed directly to Matter controllers.
