### PR TITLE
fix: subscribeHandler misses split-entity devices, dropping controller attribute writes

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1210,8 +1210,8 @@ export class HomeAssistantPlatform extends MatterbridgeDynamicPlatform {
     const state = this.ha.hassStates.get(entity.entity_id);
     let endpoint: MatterbridgeEndpoint | undefined;
     if (isDeviceEntity(entity)) {
-      // Device entity
-      const matterbridgeDevice = this.matterbridgeDevices.get(entity.device_id);
+      // Device entity. Split entities are registered by entity_id, so fall back to it when the device_id lookup fails.
+      const matterbridgeDevice = this.matterbridgeDevices.get(entity.device_id) ?? this.matterbridgeDevices.get(entity.entity_id);
       if (!matterbridgeDevice) {
         this.log.debug(`Subscribe handler: Matterbridge device ${entity.device_id} for ${entity.entity_id} not found`);
         return;


### PR DESCRIPTION
## Problem

Entities exposed through `splitEntities` that belong to a Home Assistant device are discovered by controllers but **do not respond to attribute writes**. The visible symptom: a HA `fan` bridged as a split entity shows up in Alexa, Alexa sends the command, but nothing happens in Home Assistant.

Lights mostly hide the bug because `onOff` arrives as a **command invoke** (handled by `commandHandler`), while Matter fans are controlled through **FanControl attribute writes** (`fanMode`, `percentSetting`, `airflowDirection`), which flow through `subscribeHandler`.

## Root cause

Split-entity devices are registered in `matterbridgeDevices` keyed by **`entity_id`**:

```ts
// registerSplitEntities
this.matterbridgeDevices.set(entity.entity_id, mutableDevice.getEndpoint());
```

but `subscribeHandler` only looks them up by **`entity.device_id`** (a split entity still has a `device_id`, so `isDeviceEntity()` is true):

```ts
const matterbridgeDevice = this.matterbridgeDevices.get(entity.device_id);
if (!matterbridgeDevice) {
  this.log.debug(...); // silent drop at debug level
  return;
}
```

The lookup fails and the write is silently discarded.

## Fix

Fall back to the `entity_id` lookup when the `device_id` lookup fails. The subsequent child-endpoint resolution already works because `endpointNames` maps the split entity to `''` (main endpoint) under the Merge strategy.

## How I verified

Real setup: HA fans (BLE ADV ceiling fans, `supported_features: 61`) exposed via `splitEntities`, commissioned to Alexa through Matterbridge 3.4.1 / matterbridge-hass 1.4.0.

Before — Alexa writes arrive and are dropped (no log from the plugin, no HA service call):
```
[18:22:31.092] [InteractionServer] [info] Write « ... 140.fanControl.state.fanMode
[18:22:50.901] [InteractionServer] [info] Write « ... 140.fanControl.state.percentSetting
```

After (same patch applied to dist on the running install) — the handler fires and the HA fan turns on/changes speed:
```
[00:55:56.416] [Ventilador Salita] [info] Subscribed attribute FanControl:percentSetting on endpoint VentiladorSalita:140 changed from 57 to 50
[00:55:56.983] [Ventilador Salita] [info] Subscribed attribute FanControl:fanMode on endpoint VentiladorSalita:140 changed from 5 to 3
```

`npm run build` passes. I did not add a test because the vitest suite mocks at a higher level than this lookup; happy to add one if you point me at the preferred pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)